### PR TITLE
Fix SDMX time period input format

### DIFF
--- a/src/vtlengine/DataTypes/TimeHandling.py
+++ b/src/vtlengine/DataTypes/TimeHandling.py
@@ -180,7 +180,7 @@ class TimePeriodHandler:
 
     @staticmethod
     def _check_year(year: int) -> None:
-        if year < 1900 or year > 9999:
+        if year < 0 or year > 9999:
             raise SemanticError("2-1-19-10", year=year)
             # raise ValueError(f'Invalid year {year}, must be between 1900 and 9999.')
 

--- a/src/vtlengine/files/parser/_time_checking.py
+++ b/src/vtlengine/files/parser/_time_checking.py
@@ -95,6 +95,11 @@ def check_time_period(value: str) -> str:
     if isinstance(value, int):
         value = str(value)
     value = value.replace(" ", "")
+
+    match = re.fullmatch(r"^(\d{4})-(\d{2})$", value)
+    if match:
+        value = f"{match.group(1)}-M{match.group(2)}"
+
     period_result = re.fullmatch(period_pattern, value)
     if period_result is not None:
         result = TimePeriodHandler(value)


### PR DESCRIPTION
Fixed DSMX-like time period month values are now set as {yyyy}-M{mm}