### PR TITLE
Add persistent attribute to Dataset and Scalar

### DIFF
--- a/src/vtlengine/API/_InternalApi.py
+++ b/src/vtlengine/API/_InternalApi.py
@@ -420,6 +420,24 @@ def load_external_routines(input: Union[Dict[str, Any], Path, str]) -> Any:
     return external_routines
 
 
+def _get_persistence(
+    datasets: Dict[str, Union[Dataset, Scalar]], ast: Start
+) -> Dict[str, Union[Dataset, Scalar]]:
+    """
+    Set the persistence attribute to the datasets according to the AST.
+    """
+    persistent = []
+    for child in ast.children:
+        if isinstance(child, PersistentAssignment) and hasattr(child.left, "value"):
+            persistent.append(child.left.value)
+
+    ds = {}
+    for k, v in datasets.items():
+        v.persistent = k in persistent
+        ds[k] = v
+    return ds
+
+
 def _return_only_persistent_datasets(
     datasets: Dict[str, Union[Dataset, Scalar]], ast: Start
 ) -> Dict[str, Union[Dataset, Scalar]]:

--- a/src/vtlengine/API/__init__.py
+++ b/src/vtlengine/API/__init__.py
@@ -14,6 +14,7 @@ from pysdmx.util import parse_urn
 from vtlengine.API._InternalApi import (
     _check_output_folder,
     _check_script,
+    _get_persistence,
     _return_only_persistent_datasets,
     ast_to_sdmx,
     load_datasets,
@@ -368,6 +369,7 @@ def run(
                 format_time_period_external_representation(obj, time_period_representation)
 
     # Returning only persistent datasets
+    result = _get_persistence(result, ast)
     if return_only_persistent:
         return _return_only_persistent_datasets(result, ast)
     return result

--- a/src/vtlengine/Interpreter/__init__.py
+++ b/src/vtlengine/Interpreter/__init__.py
@@ -399,16 +399,10 @@ class InterpreterAnalyzer(ASTTemplate):
         self.is_from_assignment = False
         right_operand: Union[Dataset, DataComponent] = self.visit(node.right)
         self.is_from_component_assignment = False
-        result = Assignment.analyze(left_operand, right_operand)
-        if isinstance(result, (Dataset, Scalar)):
-            result.persistent = False
-        return result
+        return Assignment.analyze(left_operand, right_operand)
 
     def visit_PersistentAssignment(self, node: AST.PersistentAssignment) -> Any:
-        result = self.visit_Assignment(node)
-        if isinstance(result, (Dataset, Scalar)):
-            result.persistent = True
-        return result
+        return self.visit_Assignment(node)
 
     def visit_ParFunction(self, node: AST.ParFunction) -> Any:
         return self.visit(node.operand)


### PR DESCRIPTION
Closes #307 

## Changelog

- A **persistent** flag was added to **Dataset** and **Scalar** objects. 
  - Now the resulting Datasets and Scalars can be distinguished without using the AST.
- Added copy into VarID return statements to avoid reference overwriting.