### PR TITLE
Fixed handling of comments at the end of the script. Added relevant tests.

### DIFF
--- a/src/vtlengine/AST/ASTComment.py
+++ b/src/vtlengine/AST/ASTComment.py
@@ -37,6 +37,7 @@ def create_ast_with_comments(text: str) -> Start:
     # Call the create_ast function to generate the AST from channel 0
     ast = create_ast(text)
 
+    text = text if text.endswith("\n") else text + "\n"
     # Reading the script on channel 2 to get the comments
     lexer_ = Lexer(InputStream(text))
     stream = CommonTokenStream(lexer_, channel=2)

--- a/tests/AST/data/vtl/comments_end_line.vtl
+++ b/tests/AST/data/vtl/comments_end_line.vtl
@@ -1,0 +1,2 @@
+DS_A <- DS_1 * 10;
+//Comment at the end of the line

--- a/tests/AST/test_AST_String.py
+++ b/tests/AST/test_AST_String.py
@@ -24,6 +24,7 @@ params = [
     "GH_347.vtl",
     "GH_352.vtl",
     "GH_358.vtl",
+    "comments_end_line.vtl",
 ]
 
 params_prettier = [
@@ -90,6 +91,17 @@ def test_comments_parsing():
     assert "*/" in ast.children[2].value[-2:]
     assert ast.children[2].line_start == 3
     assert ast.children[2].line_stop == 6
+
+
+def test_comments_end_line_parsing():
+    with open(vtl_filepath / "comments_end_line.vtl", "r") as file:
+        script = file.read()
+
+    ast = create_ast_with_comments(script)
+    assert len(ast.children) == 2
+    assert isinstance(ast.children[1], Comment)
+    assert ast.children[1].line_start == 2
+    assert ast.children[1].line_stop == 2
 
 
 def test_check_ast_string_output():


### PR DESCRIPTION
# Summary of  changes

- Fixed bug where the comment at the end of a script was omitted when using create_ast_with_comments