### PR TITLE
Fix #530: Auto-trigger docs workflow on documentation PR merge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,11 +6,17 @@ on:
 
   workflow_dispatch:
 
+  pull_request:
+    types: [ closed ]
+    branches: [ main ]
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
+  issues: read
+  pull-requests: read
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -19,8 +25,70 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Check if a merged PR is linked to a documentation issue
+  check-docs-label:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - name: Check for documentation label
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const merged = context.payload.pull_request.merged;
+            if (!merged) {
+              core.setOutput('should_build', 'false');
+              core.info('PR was closed without merging. Skipping.');
+              return;
+            }
+
+            const branch = context.payload.pull_request.head.ref;
+            core.info(`PR branch: ${branch}`);
+
+            const match = branch.match(/^cr-(\d+)$/);
+            if (!match) {
+              core.setOutput('should_build', 'false');
+              core.info('Branch does not match cr-{number} pattern. Skipping.');
+              return;
+            }
+
+            const issueNumber = parseInt(match[1], 10);
+            core.info(`Extracted issue number: ${issueNumber}`);
+
+            try {
+              const issue = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+
+              const issueLabels = issue.data.labels.map(l => l.name);
+              core.info(`Issue #${issueNumber} labels: ${issueLabels.join(', ') || '(none)'}`);
+
+              if (issueLabels.includes('documentation')) {
+                core.setOutput('should_build', 'true');
+                core.info(`Issue #${issueNumber} has "documentation" label. Will build docs.`);
+              } else {
+                core.setOutput('should_build', 'false');
+                core.info(`Issue #${issueNumber} does not have "documentation" label. Skipping.`);
+              }
+            } catch (error) {
+              core.warning(`Could not fetch issue #${issueNumber}: ${error.message}`);
+              core.setOutput('should_build', 'false');
+            }
+
   # Build job
   build:
+    needs: [ check-docs-label ]
+    if: |
+      always() && !cancelled() &&
+      (
+        github.event_name == 'release' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.check-docs-label.outputs.should_build == 'true'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Add `pull_request: types: [closed]` trigger to the docs workflow targeting `main`
- Add `check-docs-label` job that extracts the issue number from the branch name (`cr-{number}`) and checks if the linked issue has the `documentation` label
- Make the `build` job conditional: runs on release, manual dispatch, or when the docs label check passes

## Behavior

| Trigger | check-docs-label | build | deploy |
| --- | --- | --- | --- |
| Release published | Skipped | Runs | Runs |
| Manual dispatch | Skipped | Runs | Runs |
| PR closed (no merge) | `false` | Skipped | Skipped |
| PR merged, no doc label | `false` | Skipped | Skipped |
| PR merged, issue has `documentation` label | `true` | Runs | Runs |