### PR TITLE
Fix #609: Apply operator fails on semantic execution

### DIFF
--- a/src/vtlengine/Operators/Join.py
+++ b/src/vtlengine/Operators/Join.py
@@ -409,9 +409,12 @@ class Apply(Operator):
     def validate(cls, dataset: Dataset, child: Any, op_map: Dict[str, Any]) -> Dataset:
         if isinstance(child, list):
             for c in child:
-                cls._check_bin_expr(dataset, c, op_map)
+                dataset = cls.validate(dataset, c, op_map)
         else:
             cls._check_bin_expr(dataset, child, op_map)
+            left_dataset = cls.create_dataset("left", child.left.value, dataset)
+            right_dataset = cls.create_dataset("right", child.right.value, dataset)
+            dataset, _ = cls.get_common_components(left_dataset, right_dataset)
 
         return dataset
 
@@ -448,7 +451,12 @@ class Apply(Operator):
             for component in dataset.components.values()
             if component.name.startswith(prefix) or component.role is Role.IDENTIFIER
         }
-        data = dataset.data[list(components.keys())] if dataset.data is not None else pd.DataFrame()
+        comp_names = list(components.keys())
+        data = (
+            dataset.data[comp_names]
+            if dataset.data is not None
+            else pd.DataFrame(columns=comp_names)
+        )
 
         for component in components.values():
             component.name = (

--- a/tests/Semantic/data/DataStructure/input/GH_609-1.json
+++ b/tests/Semantic/data/DataStructure/input/GH_609-1.json
@@ -1,0 +1,21 @@
+{
+    "datasets": [
+        {
+            "name": "DS_1",
+            "DataStructure": [
+                {
+                    "name": "Id_1",
+                    "type": "Integer",
+                    "role": "Identifier",
+                    "nullable": false
+                },
+                {
+                    "name": "Me_1",
+                    "type": "Number",
+                    "role": "Measure",
+                    "nullable": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Semantic/data/DataStructure/output/GH_609-1.json
+++ b/tests/Semantic/data/DataStructure/output/GH_609-1.json
@@ -1,0 +1,21 @@
+{
+    "datasets": [
+        {
+            "name": "DS_r",
+            "DataStructure": [
+                {
+                    "name": "Id_1",
+                    "type": "Integer",
+                    "role": "Identifier",
+                    "nullable": false
+                },
+                {
+                    "name": "Me_1",
+                    "type": "Number",
+                    "role": "Measure",
+                    "nullable": true
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Semantic/data/vtl/GH_609.vtl
+++ b/tests/Semantic/data/vtl/GH_609.vtl
@@ -1,0 +1,1 @@
+DS_r := inner_join (DS_1 as d1, DS_1 as d2 apply d1 + d2);

--- a/tests/Semantic/test_semantic.py
+++ b/tests/Semantic/test_semantic.py
@@ -1854,6 +1854,19 @@ class JoinTests(SemanticHelper):
 
         self.BaseTest(code=code, number_inputs=number_inputs, references_names=references_names)
 
+    def test_GH_609(self):
+        """
+        Dataset --> Dataset
+        Status:
+        Expression: DS_r := inner_join (DS_1 as d1, DS_1 as d2 apply d1 + d2);
+        Description: Apply operation fails on semantic run
+        """
+        code = "GH_609"
+        number_inputs = 1
+        references_names = ["1"]
+
+        self.BaseTest(code=code, number_inputs=number_inputs, references_names=references_names)
+
 
 class AggregateTests(SemanticHelper):
     """ """


### PR DESCRIPTION
## Summary

Apply validate now handle BinOps like the evaluate method.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [x] Documentation updated (if applicable)