### PR TITLE
Route all test patterns through DuckDB backend

### DIFF
--- a/tests/API/test_api.py
+++ b/tests/API/test_api.py
@@ -10,6 +10,7 @@ from pysdmx.model import (
 )
 
 import vtlengine.DataTypes as DataTypes
+from tests.Helper import _use_duckdb_backend
 from vtlengine.API import (
     prettify,
     run,
@@ -858,6 +859,7 @@ def test_run(script, data_structures, datapoints, value_domains, external_routin
         value_domains,
         external_routines,
         return_only_persistent=False,
+        use_duckdb=_use_duckdb_backend(),
     )
     reference = {
         "DS_r": Dataset(
@@ -937,6 +939,7 @@ def test_run_only_persistent_results(
         external_routines,
         output_folder=output_path,
         return_only_persistent=True,
+        use_duckdb=_use_duckdb_backend(),
     )
 
     reference = {
@@ -991,6 +994,7 @@ def test_run_only_persistent(script, data_structures, datapoints, value_domains,
         value_domains,
         external_routines,
         return_only_persistent=True,
+        use_duckdb=_use_duckdb_backend(),
     )
     reference = {
         "DS_r2": Dataset(
@@ -1062,6 +1066,7 @@ def test_readme_example():
         data_structures=data_structures,
         datapoints=datapoints,
         return_only_persistent=False,
+        use_duckdb=_use_duckdb_backend(),
     )
 
     assert run_result == {
@@ -1126,6 +1131,7 @@ def test_readme_run():
         data_structures=data_structures,
         datapoints=datapoints,
         return_only_persistent=False,
+        use_duckdb=_use_duckdb_backend(),
     )
 
     assert run_result == {
@@ -1240,6 +1246,7 @@ def test_non_mandatory_fill_at():
         data_structures=data_structures,
         datapoints=datapoints,
         return_only_persistent=False,
+        use_duckdb=_use_duckdb_backend(),
     )
 
     assert run_result == {
@@ -1335,6 +1342,7 @@ def test_non_mandatory_fill_me():
         data_structures=data_structures,
         datapoints=datapoints,
         return_only_persistent=False,
+        use_duckdb=_use_duckdb_backend(),
     )
 
     assert run_result == {
@@ -1583,6 +1591,7 @@ def test_run_with_scalars(data_structures, datapoints, tmp_path):
         scalar_values=scalars,
         output_folder=output_folder,
         return_only_persistent=True,
+        use_duckdb=_use_duckdb_backend(),
     )
     reference = {
         "DS_r": Dataset(
@@ -1655,6 +1664,7 @@ def test_run_with_scalar_being_none(data_structures, datapoints, tmp_path):
         scalar_values=scalars,
         output_folder=output_folder,
         return_only_persistent=True,
+        use_duckdb=_use_duckdb_backend(),
     )
     reference = {
         "DS_r": Dataset(
@@ -1871,6 +1881,7 @@ def test_with_multiple_vd_and_ext_routines():
         datapoints=datapoints,
         value_domains=value_domains,
         external_routines=external_routines,
+        use_duckdb=_use_duckdb_backend(),
     )
 
     reference = {

--- a/tests/Additional/test_additional_scalars.py
+++ b/tests/Additional/test_additional_scalars.py
@@ -4,13 +4,29 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from tests.Helper import TestHelper
+from tests.Helper import TestHelper, _use_duckdb_backend
 from vtlengine import DataTypes
 from vtlengine.API import create_ast, run
 from vtlengine.DataTypes import Boolean, Integer, Null, Number, String
 from vtlengine.Exceptions import SemanticError
 from vtlengine.Interpreter import InterpreterAnalyzer
 from vtlengine.Model import Component, Dataset, Role, Scalar
+
+
+def _run_scalar(expression):
+    """Run a scalar VTL expression using the configured backend."""
+    if _use_duckdb_backend():
+        return run(
+            script=expression,
+            data_structures={"datasets": []},
+            datapoints={},
+            return_only_persistent=False,
+            use_duckdb=True,
+        )
+    else:
+        ast = create_ast(expression)
+        interpreter = InterpreterAnalyzer({})
+        return interpreter.visit(ast)
 
 
 class AdditionalScalarsTests(TestHelper):
@@ -313,9 +329,7 @@ params_filter_operations = [
 def test_string_operators(text, reference):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = _run_scalar(expression)
     assert result["DS_r"].value == reference
     assert result["DS_r"].data_type == String
 
@@ -324,9 +338,7 @@ def test_string_operators(text, reference):
 def test_instr_op_test(text, reference):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = _run_scalar(expression)
     assert result["DS_r"].value == reference
     assert result["DS_r"].data_type == Integer
 
@@ -335,19 +347,15 @@ def test_instr_op_test(text, reference):
 def test_exception_string_op(text, exception_message):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
     with pytest.raises(SemanticError, match=f".*{exception_message}"):
-        interpreter.visit(ast)
+        _run_scalar(expression)
 
 
 @pytest.mark.parametrize("text, reference", numeric_params)
 def test_numeric_operators(text, reference):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = _run_scalar(expression)
     if reference is None:
         assert result["DS_r"].value is None
     else:
@@ -359,31 +367,27 @@ def test_numeric_operators(text, reference):
 def test_exception_numeric_op(text, exception_message):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
     with pytest.raises(Exception, match=exception_message):
-        interpreter.visit(ast)
+        _run_scalar(expression)
 
 
 @pytest.mark.parametrize("code, text", ds_param)
 def test_datasets_params(code, text):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    datasets = AdditionalScalarsTests.LoadInputs(code, 1)
-    reference = AdditionalScalarsTests.LoadOutputs(code, ["DS_r"])
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer(datasets)
-    result = interpreter.visit(ast)
-    assert result == reference
+    AdditionalScalarsTests.BaseTest(
+        code=code,
+        number_inputs=1,
+        references_names=["DS_r"],
+        text=expression,
+    )
 
 
 @pytest.mark.parametrize("text, reference", boolean_params)
 def test_bool_op_test(text, reference):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = _run_scalar(expression)
     assert result["DS_r"].value == reference
 
 
@@ -391,9 +395,7 @@ def test_bool_op_test(text, reference):
 def test_comp_op_test(text, reference):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = _run_scalar(expression)
     assert result["DS_r"].value == reference
 
 
@@ -432,6 +434,7 @@ def test_run_scalars_operations(script, reference, tmp_path):
         scalar_values=scalar_values,
         output_folder=tmp_path,
         return_only_persistent=True,
+        use_duckdb=_use_duckdb_backend(),
     )
     for k, expected_scalar in reference.items():
         assert k in run_result
@@ -480,5 +483,6 @@ def test_filter_op(script, reference):
         datapoints=datapoints,
         scalar_values=scalar_values,
         return_only_persistent=True,
+        use_duckdb=_use_duckdb_backend(),
     )
     assert run_result == reference

--- a/tests/DateTime/test_datetime.py
+++ b/tests/DateTime/test_datetime.py
@@ -4,6 +4,7 @@ from typing import Any, List
 import pandas as pd
 import pytest
 
+from tests.Helper import _use_duckdb_backend
 from vtlengine import run
 from vtlengine.API import create_ast
 from vtlengine.DataTypes import Date, Integer
@@ -11,6 +12,22 @@ from vtlengine.DataTypes._time_checking import check_date
 from vtlengine.DataTypes.TimeHandling import check_max_date
 from vtlengine.Exceptions import InputValidationException, RunTimeError
 from vtlengine.Interpreter import InterpreterAnalyzer
+
+
+def _run_scalar(expression):
+    """Run a scalar VTL expression using the configured backend."""
+    if _use_duckdb_backend():
+        return run(
+            script=expression,
+            data_structures={"datasets": []},
+            datapoints={},
+            return_only_persistent=False,
+            use_duckdb=True,
+        )
+    else:
+        ast = create_ast(expression)
+        interpreter = InterpreterAnalyzer({})
+        return interpreter.visit(ast)
 
 
 def _to_pylist(series: pd.Series) -> List[Any]:  # type: ignore[type-arg]
@@ -505,9 +522,7 @@ def test_check_max_date_none():
 def test_unary_time_scalar_datetime(text, reference):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = _run_scalar(expression)
     assert result["DS_r"].value == reference
     assert result["DS_r"].data_type == Integer
 
@@ -516,9 +531,7 @@ def test_unary_time_scalar_datetime(text, reference):
 def test_datediff_datetime(text, reference):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = _run_scalar(expression)
     assert result["DS_r"].value == reference
     assert result["DS_r"].data_type == Integer
 
@@ -527,9 +540,7 @@ def test_datediff_datetime(text, reference):
 def test_dateadd_datetime(text, reference):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = _run_scalar(expression)
     assert result["DS_r"].value == reference
     assert result["DS_r"].data_type == Date
 
@@ -549,7 +560,12 @@ DS_1_Structure = {
 
 def _run_ds(script, input_values):
     data_df = pd.DataFrame({"Id_1": list(range(1, len(input_values) + 1)), "Me_1": input_values})
-    result = run(script=script, data_structures=DS_1_Structure, datapoints={"DS_1": data_df})
+    result = run(
+        script=script,
+        data_structures=DS_1_Structure,
+        datapoints={"DS_1": data_df},
+        use_duckdb=_use_duckdb_backend(),
+    )
     return _to_pylist(result["DS_r"].data["Me_1"])
 
 
@@ -600,7 +616,12 @@ def test_dataset_extraction_operator(op, input_values, expected):
             "Me_2": [0] * len(input_values),
         }
     )
-    result = run(script=script, data_structures=_DS_1_INT_MEASURE, datapoints={"DS_1": data_df})
+    result = run(
+        script=script,
+        data_structures=_DS_1_INT_MEASURE,
+        datapoints={"DS_1": data_df},
+        use_duckdb=_use_duckdb_backend(),
+    )
     assert _to_pylist(result["DS_r"].data["Me_2"]) == expected
 
 
@@ -629,7 +650,12 @@ def test_dataset_datediff_with_datetime():
             "Me_2": ["2020-01-10 23:59:59", "2020-06-15 23:59:59"],
         }
     )
-    result = run(script=script, data_structures=data_structures, datapoints={"DS_1": data_df})
+    result = run(
+        script=script,
+        data_structures=data_structures,
+        datapoints={"DS_1": data_df},
+        use_duckdb=_use_duckdb_backend(),
+    )
     assert _to_pylist(result["DS_r"].data["Me_2"]) == [9, 0]
 
 
@@ -641,6 +667,7 @@ def test_flow_to_stock_datetime(input_data, expected_Id_2, expected_Me_1):
         script=script,
         data_structures=Time_id_structure,
         datapoints={"DS_1": data_df},
+        use_duckdb=_use_duckdb_backend(),
     )
     result_data = result["DS_r"].data
     if expected_Id_2 is not None:
@@ -659,6 +686,7 @@ def test_fill_time_series(lim_method, Id_1, Id_2, Me_1, exp_Id_1, exp_Id_2, exp_
         script=script,
         data_structures=Time_id_str_structure,
         datapoints={"DS_1": data_df},
+        use_duckdb=_use_duckdb_backend(),
     )
     result_data = result["DS_r"].data.sort_values(["Id_1", "Id_2"]).reset_index(drop=True)
     assert _to_pylist(result_data["Id_1"]) == exp_Id_1
@@ -677,6 +705,7 @@ def test_fill_time_series_period(lim_method, Id_1, Id_2, Me_1, exp_Id_1, exp_Id_
         script=script,
         data_structures=Time_Period_structure,
         datapoints={"DS_1": data_df},
+        use_duckdb=_use_duckdb_backend(),
     )
     result_data = result["DS_r"].data.sort_values(["Id_1", "Id_2"]).reset_index(drop=True)
     assert _to_pylist(result_data["Id_1"]) == exp_Id_1
@@ -688,9 +717,7 @@ def test_fill_time_series_period(lim_method, Id_1, Id_2, Me_1, exp_Id_1, exp_Id_
 def test_time_agg_scalar_datetime(args, expected):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := time_agg({args});"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = _run_scalar(expression)
     assert result["DS_r"].value == expected
     assert result["DS_r"].data_type == Date
 
@@ -703,6 +730,7 @@ def test_time_agg_dataset_datetime(args, input_data, expected):
         script=script,
         data_structures=DS_1_Structure,
         datapoints={"DS_1": data_df},
+        use_duckdb=_use_duckdb_backend(),
     )
     assert _to_pylist(result["DS_r"].data["Me_1"]) == expected
 
@@ -712,7 +740,12 @@ def test_time_agg_dataset_datetime(args, input_data, expected):
 )
 def test_timeshift_datetime(script, Id_1, Id_2, Me_1, Id_2_reference, Me_1_reference):
     data_df = pd.DataFrame({"Id_1": Id_1, "Id_2": Id_2, "Me_1": Me_1})
-    result = run(script=script, data_structures=Time_id_structure, datapoints={"DS_1": data_df})
+    result = run(
+        script=script,
+        data_structures=Time_id_structure,
+        datapoints={"DS_1": data_df},
+        use_duckdb=_use_duckdb_backend(),
+    )
     result_data = result["DS_r"].data
     assert result_data["Id_2"].astype(str).tolist() == Id_2_reference
     assert _to_pylist(result_data["Me_1"]) == Me_1_reference

--- a/tests/DocScripts/test_doc_examples.py
+++ b/tests/DocScripts/test_doc_examples.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from tests.DocScripts._rst_code_extractor import CodeBlock, extract_python_blocks, is_runnable
+from tests.Helper import _use_duckdb_backend
 from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import Dataset, Scalar
 
@@ -56,6 +57,16 @@ def _exec_block(source: str, filename: str, capture_results: bool = False) -> di
     """Execute a code block and return the resulting namespace."""
     if capture_results:
         source = _preprocess_for_result_capture(source)
+    # When DuckDB backend is active, patch run() calls to include use_duckdb=True
+    if _use_duckdb_backend():
+        source = source.replace(
+            "run(script=script,",
+            "run(script=script, use_duckdb=True,",
+        )
+        source = source.replace(
+            "run(script, data_structures",
+            "run(script, data_structures",
+        )
     namespace: dict[str, object] = {}
     exec(compile(source, filename, "exec"), namespace)  # noqa: S102
     return namespace

--- a/tests/NewOperators/Case/test_case.py
+++ b/tests/NewOperators/Case/test_case.py
@@ -4,9 +4,8 @@ from pathlib import Path
 import pytest
 from pytest import mark
 
-from vtlengine.API import create_ast
+from tests.NewOperators.conftest import run_expression
 from vtlengine.Exceptions import SemanticError
-from vtlengine.Interpreter import InterpreterAnalyzer
 
 pytestmark = mark.input_path(Path(__file__).parent / "data")
 
@@ -83,22 +82,17 @@ error_param = [
 
 
 @pytest.mark.parametrize("code, expression", ds_param)
-def test_case_ds(load_input, load_reference, code, expression):
+def test_case_ds(load_input, load_reference, duckdb_input, code, expression):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer(load_input)
-    result = interpreter.visit(ast)
+    result = run_expression(expression, load_input, duckdb_input)
     assert result == load_reference
 
 
 @pytest.mark.parametrize("code, expression, error_code", error_param)
-def test_errors(load_input, code, expression, error_code):
+def test_errors(load_input, duckdb_input, code, expression, error_code):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    datasets = load_input
     with pytest.raises(SemanticError) as context:
-        ast = create_ast(expression)
-        interpreter = InterpreterAnalyzer(datasets)
-        interpreter.visit(ast)
+        run_expression(expression, load_input, duckdb_input)
     result = error_code == str(context.value.args[1])
     if result is False:
         print(f"\n{error_code} != {context.value.args[1]}")

--- a/tests/NewOperators/Random/test_random.py
+++ b/tests/NewOperators/Random/test_random.py
@@ -4,9 +4,8 @@ from pathlib import Path
 import pytest
 from pytest import mark
 
-from vtlengine.API import create_ast
+from tests.NewOperators.conftest import run_expression
 from vtlengine.Exceptions import SemanticError
-from vtlengine.Interpreter import InterpreterAnalyzer
 
 pytestmark = mark.input_path(Path(__file__).parent / "data")
 
@@ -28,22 +27,17 @@ error_param = [
 
 
 @pytest.mark.parametrize("code, expression", ds_param)
-def test_case_ds(load_input, load_reference, code, expression):
+def test_case_ds(load_input, load_reference, duckdb_input, code, expression):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer(load_input)
-    result = interpreter.visit(ast)
+    result = run_expression(expression, load_input, duckdb_input)
     assert result == load_reference
 
 
 @pytest.mark.parametrize("code, expression, error_code", error_param)
-def test_errors(load_input, code, expression, error_code):
+def test_errors(load_input, duckdb_input, code, expression, error_code):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    datasets = load_input
     with pytest.raises(SemanticError) as context:
-        ast = create_ast(expression)
-        interpreter = InterpreterAnalyzer(datasets)
-        interpreter.visit(ast)
+        run_expression(expression, load_input, duckdb_input)
     result = error_code == str(context.value.args[1])
     if result is False:
         print(f"\n{error_code} != {context.value.args[1]}")

--- a/tests/NewOperators/Time/test_datediff.py
+++ b/tests/NewOperators/Time/test_datediff.py
@@ -4,10 +4,9 @@ from pathlib import Path
 import pytest
 from pytest import mark
 
-from vtlengine.API import create_ast
+from tests.NewOperators.conftest import run_expression, run_scalar_expression
 from vtlengine.DataTypes import Integer
 from vtlengine.Exceptions import RunTimeError, SemanticError
-from vtlengine.Interpreter import InterpreterAnalyzer
 
 pytestmark = mark.input_path(Path(__file__).parent / "data")
 
@@ -39,11 +38,9 @@ scalar_time_error_params = [
 
 
 @pytest.mark.parametrize("code, expression", ds_param)
-def test_case_ds(load_input, load_reference, code, expression):
+def test_case_ds(load_input, load_reference, duckdb_input, code, expression):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer(load_input)
-    result = interpreter.visit(ast)
+    result = run_expression(expression, load_input, duckdb_input)
     assert result == load_reference
 
 
@@ -51,21 +48,16 @@ def test_case_ds(load_input, load_reference, code, expression):
 def test_unary_time_scalar(text, reference):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = run_scalar_expression(expression)
     assert result["DS_r"].value == reference
     assert result["DS_r"].data_type == Integer
 
 
 @pytest.mark.parametrize("code, expression, error_code", error_param)
-def test_errors(load_input, code, expression, error_code):
+def test_errors(load_input, duckdb_input, code, expression, error_code):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    datasets = load_input
     with pytest.raises(SemanticError) as context:
-        ast = create_ast(expression)
-        interpreter = InterpreterAnalyzer(datasets)
-        interpreter.visit(ast)
+        run_expression(expression, load_input, duckdb_input)
     result = error_code == str(context.value.args[1])
     if result is False:
         print(f"\n{error_code} != {context.value.args[1]}")
@@ -76,7 +68,5 @@ def test_errors(load_input, code, expression, error_code):
 def test_errors_time_scalar(text, exception_type, exception_message):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
     with pytest.raises(exception_type, match=f".*{exception_message}"):
-        interpreter.visit(ast)
+        run_scalar_expression(expression)

--- a/tests/NewOperators/Time/test_new_time.py
+++ b/tests/NewOperators/Time/test_new_time.py
@@ -4,9 +4,8 @@ from pathlib import Path
 import pytest
 from pytest import mark
 
-from vtlengine.API import create_ast
+from tests.NewOperators.conftest import run_expression
 from vtlengine.Exceptions import SemanticError
-from vtlengine.Interpreter import InterpreterAnalyzer
 
 pytestmark = mark.input_path(Path(__file__).parent / "data")
 
@@ -39,22 +38,17 @@ error_param = [
 
 
 @pytest.mark.parametrize("code, expression", ds_param)
-def test_case_ds(load_input, load_reference, code, expression):
+def test_case_ds(load_input, load_reference, duckdb_input, code, expression):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer(load_input)
-    result = interpreter.visit(ast)
+    result = run_expression(expression, load_input, duckdb_input)
     assert result == load_reference
 
 
 @pytest.mark.parametrize("code, expression, error_code", error_param)
-def test_errors(load_input, code, expression, error_code):
+def test_errors(load_input, duckdb_input, code, expression, error_code):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    datasets = load_input
     with pytest.raises(SemanticError) as context:
-        ast = create_ast(expression)
-        interpreter = InterpreterAnalyzer(datasets)
-        interpreter.visit(ast)
+        run_expression(expression, load_input, duckdb_input)
     result = error_code == str(context.value.args[1])
     if result is False:
         print(f"\n{error_code} != {context.value.args[1]}")

--- a/tests/NewOperators/UnaryTime/test_time_operators.py
+++ b/tests/NewOperators/UnaryTime/test_time_operators.py
@@ -4,10 +4,9 @@ from pathlib import Path
 import pytest
 from pytest import mark
 
-from vtlengine.API import create_ast
+from tests.NewOperators.conftest import run_expression, run_scalar_expression
 from vtlengine.DataTypes import Integer
 from vtlengine.Exceptions import RunTimeError, SemanticError
-from vtlengine.Interpreter import InterpreterAnalyzer
 
 pytestmark = mark.input_path(Path(__file__).parent / "data")
 
@@ -58,30 +57,23 @@ scalar_time_error_params = [
 def test_unary_time_scalar(text, reference):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
-    result = interpreter.visit(ast)
+    result = run_scalar_expression(expression)
     assert result["DS_r"].value == reference
     assert result["DS_r"].data_type == Integer
 
 
 @pytest.mark.parametrize("code, expression", ds_param)
-def test_unary_time_ds(load_input, load_reference, code, expression):
+def test_unary_time_ds(load_input, load_reference, duckdb_input, code, expression):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer(load_input)
-    result = interpreter.visit(ast)
+    result = run_expression(expression, load_input, duckdb_input)
     assert result == load_reference
 
 
 @pytest.mark.parametrize("code, expression, type_error, error_code", error_param)
-def test_errors_ds(load_input, code, expression, type_error, error_code):
+def test_errors_ds(load_input, duckdb_input, code, expression, type_error, error_code):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    datasets = load_input
     with pytest.raises(type_error) as context:
-        ast = create_ast(expression)
-        interpreter = InterpreterAnalyzer(datasets)
-        interpreter.visit(ast)
+        run_expression(expression, load_input, duckdb_input)
     result = error_code == str(context.value.args[1])
     if result is False:
         print(f"\n{error_code} != {context.value.args[1]}")
@@ -92,7 +84,5 @@ def test_errors_ds(load_input, code, expression, type_error, error_code):
 def test_errors_time_scalar(text, exception_type, exception_message):
     warnings.filterwarnings("ignore", category=FutureWarning)
     expression = f"DS_r := {text};"
-    ast = create_ast(expression)
-    interpreter = InterpreterAnalyzer({})
     with pytest.raises(exception_type, match=f".*{exception_message}"):
-        interpreter.visit(ast)
+        run_scalar_expression(expression)

--- a/tests/NewOperators/conftest.py
+++ b/tests/NewOperators/conftest.py
@@ -4,6 +4,8 @@ import os
 import pandas as pd
 import pytest
 
+from tests.Helper import _use_duckdb_backend
+from vtlengine.API import run
 from vtlengine.API._InternalApi import load_datasets_with_data
 
 
@@ -25,6 +27,28 @@ def load_datasets(base_path, code, folder_type):
     return datasets
 
 
+def _load_duckdb_paths(base_path, code, folder_type):
+    """Load data structure files and datapoint paths for DuckDB backend."""
+    input_path = base_path / "DataStructure" / folder_type
+    datapoints_path = base_path / "DataSet" / folder_type
+
+    num_inputs = len([f for f in os.listdir(input_path) if f.startswith(f"{code}-")])
+    data_structures = []
+    datapoints = {}
+
+    for i in range(1, num_inputs + 1):
+        json_file = input_path / f"{code}-{i}.json"
+        csv_file = datapoints_path / f"{code}-{i}.csv"
+        data_structures.append(json_file)
+        with open(json_file, "r") as f:
+            structure = json.load(f)
+        if "datasets" in structure:
+            for ds in structure["datasets"]:
+                datapoints[ds["name"]] = csv_file
+
+    return data_structures, datapoints
+
+
 @pytest.fixture
 def load_input(request, code):
     base_path = request.node.get_closest_marker("input_path").args[0]
@@ -35,3 +59,49 @@ def load_input(request, code):
 def load_reference(request, code):
     base_path = request.node.get_closest_marker("input_path").args[0]
     return load_datasets(base_path, code, folder_type="output")
+
+
+@pytest.fixture
+def duckdb_input(request, code):
+    """Provide data_structures and datapoints paths for DuckDB backend."""
+    base_path = request.node.get_closest_marker("input_path").args[0]
+    return _load_duckdb_paths(base_path, code, folder_type="input")
+
+
+def run_expression(expression, load_input, duckdb_input):
+    """Run a VTL expression using the configured backend."""
+    if _use_duckdb_backend():
+        data_structures, datapoints = duckdb_input
+        return run(
+            script=expression,
+            data_structures=data_structures,
+            datapoints=datapoints,
+            return_only_persistent=False,
+            use_duckdb=True,
+        )
+    else:
+        from vtlengine.API import create_ast
+        from vtlengine.Interpreter import InterpreterAnalyzer
+
+        ast = create_ast(expression)
+        interpreter = InterpreterAnalyzer(load_input)
+        return interpreter.visit(ast)
+
+
+def run_scalar_expression(expression):
+    """Run a scalar VTL expression using the configured backend."""
+    if _use_duckdb_backend():
+        return run(
+            script=expression,
+            data_structures={"datasets": []},
+            datapoints={},
+            return_only_persistent=False,
+            use_duckdb=True,
+        )
+    else:
+        from vtlengine.API import create_ast
+        from vtlengine.Interpreter import InterpreterAnalyzer
+
+        ast = create_ast(expression)
+        interpreter = InterpreterAnalyzer({})
+        return interpreter.visit(ast)

--- a/tests/ReferenceManual/test_reference_manual.py
+++ b/tests/ReferenceManual/test_reference_manual.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from vtlengine.API import create_ast
+from tests.Helper import _use_duckdb_backend
+from vtlengine.API import create_ast, run
 from vtlengine.DataTypes import SCALAR_TYPES
 from vtlengine.files.parser import load_datapoints
 from vtlengine.Interpreter import InterpreterAnalyzer
@@ -177,17 +178,51 @@ def load_dataset(dataPoints, dataStructures, dp_dir, param):
     return datasets
 
 
+def _run_rm_duckdb(vtl_path, param, value_domains=None):
+    """Run a Reference Manual test using the DuckDB backend."""
+    with open(vtl_path, "r") as f:
+        vtl = f.read()
+
+    prefix = f"{param}-"
+    data_structures = [
+        input_ds_dir / f for f in sorted(os.listdir(input_ds_dir)) if f.lower().startswith(prefix)
+    ]
+    vd_paths = None
+    if value_domains:
+        vd_paths = [value_domain_dir / f for f in os.listdir(value_domain_dir)]
+
+    datapoints = {}
+    for ds_file in data_structures:
+        with open(ds_file, "r") as f:
+            structure = json.load(f)
+        if "datasets" in structure:
+            for ds in structure["datasets"]:
+                csv_path = input_dp_dir / f"{param}-{ds['name']}.csv"
+                if csv_path.exists():
+                    datapoints[ds["name"]] = csv_path
+
+    return run(
+        script=vtl,
+        data_structures=data_structures,
+        datapoints=datapoints,
+        value_domains=vd_paths,
+        return_only_persistent=False,
+        use_duckdb=True,
+    )
+
+
 @pytest.mark.parametrize("param", params)
 def test_reference(input_datasets, reference_datasets, ast, param, value_domains):
-    # try:
     warnings.filterwarnings("ignore", category=FutureWarning)
-    input_datasets = load_dataset(*input_datasets, dp_dir=input_dp_dir, param=param)
     reference_datasets = load_dataset(*reference_datasets, dp_dir=reference_dp_dir, param=param)
-    interpreter = InterpreterAnalyzer(input_datasets, value_domains=value_domains)
-    result = interpreter.visit(ast)
+    if _use_duckdb_backend():
+        vtl_path = vtl_dir / f"RM{param:03d}.vtl"
+        result = _run_rm_duckdb(vtl_path, param, value_domains)
+    else:
+        input_datasets = load_dataset(*input_datasets, dp_dir=input_dp_dir, param=param)
+        interpreter = InterpreterAnalyzer(input_datasets, value_domains=value_domains)
+        result = interpreter.visit(ast)
     assert result == reference_datasets
-    # except NotImplementedError:
-    #     pass
 
 
 @pytest.mark.parametrize("param", params)
@@ -195,19 +230,26 @@ def test_reference_defined_operators(
     input_datasets, reference_datasets, ast_defined_operators, param, value_domains
 ):
     warnings.filterwarnings("ignore", category=FutureWarning)
-    input_datasets = load_dataset(*input_datasets, dp_dir=input_dp_dir, param=param)
     reference_datasets = load_dataset(*reference_datasets, dp_dir=reference_dp_dir, param=param)
-    interpreter = InterpreterAnalyzer(input_datasets, value_domains=value_domains)
-    result = interpreter.visit(ast_defined_operators)
+    if _use_duckdb_backend():
+        vtl_path = vtl_def_operators_dir / f"RM{param:03d}.vtl"
+        result = _run_rm_duckdb(vtl_path, param, value_domains)
+    else:
+        input_datasets = load_dataset(*input_datasets, dp_dir=input_dp_dir, param=param)
+        interpreter = InterpreterAnalyzer(input_datasets, value_domains=value_domains)
+        result = interpreter.visit(ast_defined_operators)
     assert result == reference_datasets
 
 
 @pytest.mark.parametrize("param", exceptions_tests)
 def test_reference_exceptions(input_datasets, reference_datasets, ast, param):
-    # try:
     warnings.filterwarnings("ignore", category=FutureWarning)
-    input_datasets = load_dataset(*input_datasets, dp_dir=input_dp_dir, param=param)
-    interpreter = InterpreterAnalyzer(input_datasets)
-    with pytest.raises(Exception, match="Operation not allowed for multimeasure Datasets"):
-        # result = interpreter.visit(ast) # to match with F841
-        interpreter.visit(ast)
+    if _use_duckdb_backend():
+        vtl_path = vtl_dir / f"RM{param:03d}.vtl"
+        with pytest.raises(Exception, match="Operation not allowed for multimeasure Datasets"):
+            _run_rm_duckdb(vtl_path, param)
+    else:
+        input_datasets = load_dataset(*input_datasets, dp_dir=input_dp_dir, param=param)
+        interpreter = InterpreterAnalyzer(input_datasets)
+        with pytest.raises(Exception, match="Operation not allowed for multimeasure Datasets"):
+            interpreter.visit(ast)

--- a/tests/TypeChecking/test_time_type_checking.py
+++ b/tests/TypeChecking/test_time_type_checking.py
@@ -11,6 +11,7 @@ succeed by promoting both operands to TimeInterval.
 import pandas as pd
 import pytest
 
+from tests.Helper import _use_duckdb_backend
 from vtlengine import run
 from vtlengine.DataTypes import (
     Boolean,
@@ -118,7 +119,12 @@ class TestDateTimePeriodComparison:
             "DS_date": pd.DataFrame({"Id_1": ids, "Me_1": date_vals}),
             "DS_period": pd.DataFrame({"Id_1": ids, "Me_1": period_vals}),
         }
-        result = run(script=script, data_structures=DATA_STRUCTURES, datapoints=datapoints)
+        result = run(
+            script=script,
+            data_structures=DATA_STRUCTURES,
+            datapoints=datapoints,
+            use_duckdb=_use_duckdb_backend(),
+        )
         assert "DS_r" in result
         assert list(result["DS_r"].data["bool_var"]) == expected
 
@@ -174,7 +180,12 @@ class TestDurationComparison:
         ],
     )
     def test_scalar_comparison(self, script: str, expected: bool) -> None:
-        result = run(script=script, data_structures={"datasets": []}, datapoints={})
+        result = run(
+            script=script,
+            data_structures={"datasets": []},
+            datapoints={},
+            use_duckdb=_use_duckdb_backend(),
+        )
         scalar = result["DS_r"]
         assert not isinstance(scalar, Dataset)
         assert scalar.value == expected
@@ -196,7 +207,12 @@ class TestDurationComparison:
             "DS_1": pd.DataFrame({"Id_1": [1, 2, 3], "Me_1": ["A", "M", "D"]}),
             "DS_2": pd.DataFrame({"Id_1": [1, 2, 3], "Me_1": ["M", "A", "W"]}),
         }
-        result = run(script=script, data_structures=DURATION_TWO_DS, datapoints=datapoints)
+        result = run(
+            script=script,
+            data_structures=DURATION_TWO_DS,
+            datapoints=datapoints,
+            use_duckdb=_use_duckdb_backend(),
+        )
         ds = result["DS_r"]
         assert isinstance(ds, Dataset)
         assert list(ds.data["bool_var"]) == expected
@@ -214,7 +230,12 @@ class TestDurationComparison:
         datapoints = {
             "DS_1": pd.DataFrame({"Id_1": [1, 2, 3], "Me_1": ["A", "Q", "D"]}),
         }
-        result = run(script=script, data_structures=DURATION_SINGLE_DS, datapoints=datapoints)
+        result = run(
+            script=script,
+            data_structures=DURATION_SINGLE_DS,
+            datapoints=datapoints,
+            use_duckdb=_use_duckdb_backend(),
+        )
         ds = result["DS_r"]
         assert isinstance(ds, Dataset)
         assert list(ds.data["bool_var"]) == expected
@@ -237,7 +258,12 @@ class TestDurationComparison:
         datapoints = {
             "DS_1": pd.DataFrame({"Id_1": [1, 2, 3], "Me_1": ["A", "M", "D"]}),
         }
-        result = run(script=script, data_structures=DURATION_SINGLE_DS, datapoints=datapoints)
+        result = run(
+            script=script,
+            data_structures=DURATION_SINGLE_DS,
+            datapoints=datapoints,
+            use_duckdb=_use_duckdb_backend(),
+        )
         ds = result["DS_r"]
         assert isinstance(ds, Dataset)
         assert list(ds.data["Me_2"]) == expected
@@ -297,7 +323,12 @@ class TestDurationComparison:
                 }
             ),
         }
-        result = run(script=script, data_structures=data_structures, datapoints=datapoints)
+        result = run(
+            script=script,
+            data_structures=data_structures,
+            datapoints=datapoints,
+            use_duckdb=_use_duckdb_backend(),
+        )
         ds = result["DS_r"]
         assert isinstance(ds, Dataset)
         assert list(ds.data["Me_3"]) == expected
@@ -350,7 +381,12 @@ class TestTimePeriodComparison:
         ],
     )
     def test_scalar_comparison(self, script: str, expected: bool) -> None:
-        result = run(script=script, data_structures={"datasets": []}, datapoints={})
+        result = run(
+            script=script,
+            data_structures={"datasets": []},
+            datapoints={},
+            use_duckdb=_use_duckdb_backend(),
+        )
         scalar = result["DS_r"]
         assert not isinstance(scalar, Dataset)
         assert scalar.value == expected
@@ -370,7 +406,12 @@ class TestTimePeriodComparison:
             "DS_1": pd.DataFrame({"Id_1": [1, 2, 3], "Me_1": ["2020Q1", "2021M06", "2020-A1"]}),
             "DS_2": pd.DataFrame({"Id_1": [1, 2, 3], "Me_1": ["2020Q3", "2020M12", "2021-A1"]}),
         }
-        result = run(script=script, data_structures=TIME_PERIOD_TWO_DS, datapoints=datapoints)
+        result = run(
+            script=script,
+            data_structures=TIME_PERIOD_TWO_DS,
+            datapoints=datapoints,
+            use_duckdb=_use_duckdb_backend(),
+        )
         ds = result["DS_r"]
         assert isinstance(ds, Dataset)
         assert list(ds.data["bool_var"]) == expected
@@ -388,7 +429,12 @@ class TestTimePeriodComparison:
         datapoints = {
             "DS_1": pd.DataFrame({"Id_1": [1, 2], "Me_1": ["2020Q1", "2020Q3"]}),
         }
-        result = run(script=script, data_structures=TIME_PERIOD_SINGLE_DS, datapoints=datapoints)
+        result = run(
+            script=script,
+            data_structures=TIME_PERIOD_SINGLE_DS,
+            datapoints=datapoints,
+            use_duckdb=_use_duckdb_backend(),
+        )
         ds = result["DS_r"]
         assert isinstance(ds, Dataset)
         assert list(ds.data["bool_var"]) == expected
@@ -411,7 +457,12 @@ class TestTimePeriodComparison:
         datapoints = {
             "DS_1": pd.DataFrame({"Id_1": [1, 2], "Me_1": ["2020Q1", "2020Q3"]}),
         }
-        result = run(script=script, data_structures=TIME_PERIOD_SINGLE_DS, datapoints=datapoints)
+        result = run(
+            script=script,
+            data_structures=TIME_PERIOD_SINGLE_DS,
+            datapoints=datapoints,
+            use_duckdb=_use_duckdb_backend(),
+        )
         ds = result["DS_r"]
         assert isinstance(ds, Dataset)
         assert list(ds.data["Me_2"]) == expected
@@ -462,7 +513,12 @@ class TestTimePeriodComparison:
                 }
             ),
         }
-        result = run(script=script, data_structures=data_structures, datapoints=datapoints)
+        result = run(
+            script=script,
+            data_structures=data_structures,
+            datapoints=datapoints,
+            use_duckdb=_use_duckdb_backend(),
+        )
         ds = result["DS_r"]
         assert isinstance(ds, Dataset)
         assert list(ds.data["Me_3"]) == expected


### PR DESCRIPTION
## Summary

- All test patterns now support the DuckDB backend via `VTL_ENGINE_BACKEND=duckdb`
- Previously only tests using `BaseTest` (Pattern B) routed through DuckDB
- Now Pattern I (direct InterpreterAnalyzer) and Pattern D (direct `run()`) also route through DuckDB

## Changes

**Pattern I (InterpreterAnalyzer → `run(use_duckdb=True)`):**
- `tests/NewOperators/conftest.py`: Added `run_expression()` and `run_scalar_expression()` helpers
- `tests/NewOperators/Case/test_case.py`, `Random/test_random.py`, `Time/test_datediff.py`, `Time/test_new_time.py`, `UnaryTime/test_time_operators.py`: Use new helpers
- `tests/ReferenceManual/test_reference_manual.py`: Added `_run_rm_duckdb()` helper
- `tests/Additional/test_additional_scalars.py`: Added `_run_scalar()` helper, converted `test_datasets_params` to use `BaseTest`
- `tests/DateTime/test_datetime.py`: Added `_run_scalar()` helper

**Pattern D (direct `run()` → `use_duckdb=_use_duckdb_backend()`):**
- `tests/API/test_api.py`: All 10 `run()` calls
- `tests/TypeChecking/test_time_type_checking.py`: All 11 `run()` calls
- `tests/DocScripts/test_doc_examples.py`: Patched `_exec_block` to inject `use_duckdb=True`

## Test Results

| Backend | Passed | Failed |
|---------|--------|--------|
| Pandas  | 4625   | 0      |
| DuckDB  | 4225   | 400    |

> [!NOTE]
> The DuckDB failures are expected — they represent transpiler gaps (Duration comparisons, string type checking, time period operations, UDO, etc.) that now surface because these tests are being routed through DuckDB for the first time. Previously these tests only ran on pandas.