### PR TITLE
Fix #644: Drop extra DataFrame columns not in the DataStructure

### DIFF
--- a/src/vtlengine/files/parser/__init__.py
+++ b/src/vtlengine/files/parser/__init__.py
@@ -167,6 +167,20 @@ def _parse_boolean(value: str) -> bool:
     return result
 
 
+def _drop_extra_columns(
+    components: Dict[str, Component], data: pd.DataFrame, dataset_name: str
+) -> None:
+    extra_columns = list(set(data.columns) - set(components))
+    if extra_columns:
+        warnings.warn(
+            f"Dataset {dataset_name}: dropping extra columns not defined "
+            f"in the DataStructure: {', '.join(sorted(extra_columns))}",
+            UserWarning,
+            stacklevel=3,
+        )
+        data.drop(columns=extra_columns, inplace=True)
+
+
 def _validate_pandas(
     components: Dict[str, Component], data: pd.DataFrame, dataset_name: str
 ) -> pd.DataFrame:
@@ -183,7 +197,7 @@ def _validate_pandas(
             data[name] = None
 
     # Drop any extra columns not defined in the DataStructure
-    data.drop(columns=list(set(data.columns) - set(components)), inplace=True)
+    _drop_extra_columns(components, data, dataset_name)
 
     for id_name in id_names:
         if data[id_name].isnull().any():

--- a/src/vtlengine/files/parser/__init__.py
+++ b/src/vtlengine/files/parser/__init__.py
@@ -183,7 +183,7 @@ def _validate_pandas(
             data[name] = None
 
     # Drop any extra columns not defined in the DataStructure
-    data.drop(columns=set(data.columns) - set(components), inplace=True)
+    data.drop(columns=list(set(data.columns) - set(components)), inplace=True)
 
     for id_name in id_names:
         if data[id_name].isnull().any():

--- a/src/vtlengine/files/parser/__init__.py
+++ b/src/vtlengine/files/parser/__init__.py
@@ -182,6 +182,9 @@ def _validate_pandas(
                 raise DataLoadError("0-3-1-5", name=dataset_name, comp_name=name)
             data[name] = None
 
+    # Drop any extra columns not defined in the DataStructure
+    data.drop(columns=set(data.columns) - set(components), inplace=True)
+
     for id_name in id_names:
         if data[id_name].isnull().any():
             raise DataLoadError("0-3-1-3", null_identifier=id_name, name=dataset_name)

--- a/tests/API/test_api.py
+++ b/tests/API/test_api.py
@@ -2106,6 +2106,7 @@ def test_run_drops_extra_dataframe_columns():
         )
     }
 
-    result = run(script=script, data_structures=data_structures, datapoints=datapoints)
+    with pytest.warns(UserWarning, match="dropping extra columns.*Extra_Col"):
+        result = run(script=script, data_structures=data_structures, datapoints=datapoints)
 
     assert result["DS_r"].data.columns.tolist() == ["Id_1", "Me_1"]

--- a/tests/API/test_api.py
+++ b/tests/API/test_api.py
@@ -2084,3 +2084,28 @@ def test_validate_dataset(ds_input, dp_input, is_valid, message):
     else:
         with pytest.raises(Exception, match=message):
             validate_dataset(ds_data, dp_input)
+
+
+def test_run_drops_extra_dataframe_columns():
+    """Extra columns in the input DataFrame that are not in the DataStructure are dropped."""
+    script = "DS_r <- DS_1;"
+    data_structures = {
+        "datasets": [
+            {
+                "name": "DS_1",
+                "DataStructure": [
+                    {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+                    {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+                ],
+            }
+        ]
+    }
+    datapoints = {
+        "DS_1": pd.DataFrame(
+            {"Id_1": [1, 2, 3], "Me_1": [10.0, 20.0, 30.0], "Extra_Col": ["a", "b", "c"]}
+        )
+    }
+
+    result = run(script=script, data_structures=data_structures, datapoints=datapoints)
+
+    assert result["DS_r"].data.columns.tolist() == ["Id_1", "Me_1"]


### PR DESCRIPTION
## Summary

When loading datapoints, extra columns in the input DataFrame that are not defined in the DataStructure were silently kept and propagated to the output. This PR:

- Drops extra columns in `_validate_pandas()` right after the missing-columns check
- Emits a `UserWarning` listing the dropped columns so users are aware

Fixes #644

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- Breaking changes? Users relying on extra columns surviving through the engine will no longer see them in the output. This is the correct behavior per the DataStructure contract.
- Data/SDMX compatibility concerns? None — SDMX-specific columns were already handled separately in `_sanitize_pandas_columns()`.
- Notes for release/changelog? Minor behavioral fix with a new warning.

## Notes

The fix covers all entry points (DataFrame dict, CSV files, SDMX files) since they all go through `_validate_pandas()`.