### PR TITLE
ci: native ARM wheels, cibuildwheel v3.4.1, OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: [build-wheels]
+    if: github.event_name == 'release' || github.event_name == 'repository_dispatch'
     runs-on: ubuntu-24.04
     environment: pypi
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,37 +7,47 @@ on:
     types: [ published ]
   repository_dispatch:
     types: [ release-published ]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   build-wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheels (${{ matrix.runner }} / ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - { runner: ubuntu-24.04,        arch: x86_64 }
+          - { runner: ubuntu-24.04-arm,    arch: aarch64 }
+          - { runner: macos-13,            arch: x86_64 }
+          - { runner: macos-14,            arch: arm64 }
+          - { runner: windows-2022,        arch: AMD64 }
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22
+        # cibuildwheel v3.4.1 (2026-04-02), pinned by SHA for supply-chain hygiene.
+        uses: pypa/cibuildwheel@d16cc544083d96996f923fc4b318fee3cb14b34e
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.runner }}-${{ matrix.arch }}
           path: wheelhouse/*.whl
 
   publish:
     name: Publish to PyPI
     needs: [build-wheels]
-    runs-on: ubuntu-latest
+    if: github.event_name == 'release' || github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-24.04
     environment: pypi
     permissions:
       id-token: write
@@ -52,4 +62,4 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
+          attestations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
           - { runner: macos-13,            arch: x86_64 }
           - { runner: macos-14,            arch: arm64 }
           - { runner: windows-2022,        arch: AMD64 }
+          - { runner: windows-11-arm,      arch: ARM64 }
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build wheels
-        # cibuildwheel v3.4.1 (2026-04-02), pinned by SHA for supply-chain hygiene.
-        uses: pypa/cibuildwheel@d16cc544083d96996f923fc4b318fee3cb14b34e
+        uses: pypa/cibuildwheel@d16cc544083d96996f923fc4b318fee3cb14b34e # v3.4.1
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wheels-${{ matrix.runner }}-${{ matrix.arch }}
           path: wheelhouse/*.whl
@@ -55,12 +54,12 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist
           merge-multiple: true
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
     types: [ published ]
   repository_dispatch:
     types: [ release-published ]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -46,7 +45,6 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: [build-wheels]
-    if: github.event_name == 'release' || github.event_name == 'repository_dispatch'
     runs-on: ubuntu-24.04
     environment: pypi
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,18 +136,19 @@ wheel.exclude = ["vtlengine/AST/Grammar/_cpp_parser/*.cpp", "vtlengine/AST/Gramm
 
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
-skip = "*-musllinux_*"
 test-requires = ["pytest"]
-test-command = "pytest {project}/tests -x -q --tb=short -k 'test_1' --strict-markers"
+# Smoke test: run the API-level test suite (fast, broad coverage, hits the C++ parser end-to-end)
+test-command = "pytest {project}/tests/API -x --tb=short --strict-markers"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+musllinux-x86_64-image = "musllinux_1_2"
+musllinux-aarch64-image = "musllinux_1_2"
 
 [tool.cibuildwheel.linux]
-archs = ["x86_64", "aarch64"]
 before-build = "bash {project}/scripts/setup_antlr4_runtime.sh"
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
 before-build = "bash {project}/scripts/setup_antlr4_runtime.sh"
 
 [tool.cibuildwheel.windows]
-archs = ["AMD64"]
 before-build = "bash {project}/scripts/setup_antlr4_runtime.sh"


### PR DESCRIPTION
## Summary

Modernise the release wheel pipeline so Linux aarch64 builds run on a native runner (no QEMU), wheels target `manylinux_2_28` + `musllinux_1_2`, Windows ARM64 is shipped, PyPI publish uses real OIDC trusted publishing, and the post-build smoke test exercises a meaningful subset of the suite.

Driven by the analysis at `docs/plans/2026-05-06-arm-wheel-build-improvements.md` (gitignored locally — not in this PR).

Changes:

- **`pyproject.toml`** — pin `manylinux-{x86_64,aarch64}-image = "manylinux_2_28"` and `musllinux-{x86_64,aarch64}-image = "musllinux_1_2"`. Drop `skip = "*-musllinux_*"` so musl wheels are produced. Drop per-platform `archs = […]` lists (the workflow now sets `CIBW_ARCHS` per matrix row). Replace `-k 'test_1'` smoke test with the full `tests/API` directory (203 tests, ~7 s).
- **`.github/workflows/release.yml`** — replace single-OS matrix with explicit `(runner, arch)` includes:
  - `ubuntu-24.04` / x86_64
  - `ubuntu-24.04-arm` / aarch64 (native, no QEMU)
  - `macos-13` / x86_64
  - `macos-14` / arm64
  - `windows-2022` / AMD64
  - `windows-11-arm` / ARM64

  Pin all runners to specific versions; pin every external action to a commit SHA with a trailing version comment (`actions/checkout` v6.0.2, `pypa/cibuildwheel` v3.4.1, `actions/upload-artifact` v4.6.2, `actions/download-artifact` v4.3.0, `pypa/gh-action-pypi-publish` v1.14.0). Drop `password: PYPI_TOKEN` from publish step so OIDC trusted publishing kicks in; opt into PEP 740 attestations.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`) — only YAML + TOML touched, no Python source changes
- [x] Tests pass (`pytest`) — full suite already green on `main`; the new wheel smoke test target (`pytest tests/API`) ran clean locally: 203 passed in 7.24 s
- [x] Documentation updated — N/A (CI/build configuration only)

## Impact / Risk

- **Breaking changes?** No API/behavior changes for end users. The wheels' platform tags change: aarch64 wheels will now carry `manylinux_2_28_aarch64` / `musllinux_1_2_aarch64` tags instead of (currently emulated) `manylinux2014_aarch64`. Linux installs running glibc < 2.28 will no longer find a precompiled wheel and will fall back to sdist — same baseline numpy / scipy / scikit-learn currently use, so impact is expected to be minimal.
- **Data/SDMX compatibility?** None.
- **Release/changelog notes?** Yes — note that musllinux wheels are produced from this release onward and that Windows ARM64 wheels are now available.

## Notes

**Pre-merge prerequisites that must be confirmed before cutting the next release:**

1. **PyPI trusted publisher** — confirm an entry exists at <https://pypi.org/manage/project/vtlengine/settings/publishing/> with: owner `Meaningful-Data`, repo `vtlengine`, workflow `release.yml`, environment `pypi`. Without it the OIDC token exchange will fail at publish time.
2. **Windows ARM64 validation** — the `windows-11-arm` row was added without a prior local spike (the project's C++ ANTLR4 runtime + scikit-build-core + pybind11 chain has not been exercised on Windows-on-ARM before). `fail-fast: false` ensures a Windows ARM64 failure does not abort the other five matrix cells, so the rest of the release ships even if this row breaks on its first run. To validate before relying on it, cut a pre-release tag (e.g. an `rc`) and inspect the `Build wheels (windows-11-arm / ARM64)` job. If it fails on the first run, drop the row in a follow-up commit and file a separate issue against the toolchain.

**No linked issue** — this PR is driven by an internal analysis, not a tracked GitHub issue. The automated release-notes workflow won't categorize it; release notes can mention it manually.