### PR TITLE
Fix #697: Scope test workflows to PRs and refresh support policy

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,10 +1,8 @@
 name: Testing
 
 on:
-  push:
-    branches: ["main", "duckdb/main", "dev"]
   pull_request:
-    branches: ["main", "duckdb/main", "dev"]
+    branches: ["main", "1.6.X"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,6 +5,10 @@ on:
     branches: ["main", "1.6.X"]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -1,10 +1,8 @@
 name: Ubuntu 24.04 Tests
 
 on:
-  push:
-    branches: ["main", "duckdb/main", "dev"]
   pull_request:
-    branches: ["main", "duckdb/main", "dev"]
+    branches: ["main", "1.6.X"]
 
 permissions:
   contents: read

--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: ["main", "1.6.X"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,12 @@
 
 ## Supported Versions
 
-| Version | Supported |
-| ------- | --------- |
-| 1.5.x   | Yes       |
-| < 1.5.0 | No        |
+We support the latest released minor version and the `1.6.x` long-term support line. Older versions do not receive security fixes.
+
+| Version             | Supported |
+| ------------------- | --------- |
+| 1.6.x (latest, LTS) | Yes       |
+| < 1.6.0             | No        |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Implements the code-changeable parts of #697 plus a related CI hygiene fix:

- `.github/workflows/testing.yml` and `.github/workflows/ubuntu_test_24_04.yml` now trigger only on `pull_request` targeting `main` or `1.6.X`. Push triggers and the unused `duckdb/main`/`dev` entries are removed; `workflow_dispatch` stays on `testing.yml` for manual debugging runs.
- Both workflows now declare a workflow-level `concurrency` group keyed on `${{ github.workflow }}-${{ github.head_ref || github.ref }}` with `cancel-in-progress: true`, so pushing a new commit to a PR cancels the in-flight run on the same PR instead of letting stale runs accumulate. For `workflow_dispatch` the fallback to `github.ref` keeps the same per-branch grouping.
- `SECURITY.md` rewritten so the policy is stated in prose (latest released minor + `1.6.x` LTS) with the table updated from the stale `1.5.x` baseline to `1.6.x`.

> [!IMPORTANT]
> Branch protection rules for `main` and `1.6.X` are **not** included in this PR — they must be configured by an admin through **Settings -> Branches** after this merges. The remaining checklist items in #697 (require PR, require approvals, require status checks, linear history, no admin bypass, etc.) are tracked there.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`) — N/A: pure YAML/Markdown changes, no Python touched.
- [x] Tests pass (`pytest`) — N/A for this change; the workflow trigger change itself will be exercised once this PR runs CI.
- [x] Documentation updated (if applicable) — `SECURITY.md` updated.

## Impact / Risk

- Breaking changes: workflows no longer run on direct pushes to `main` (or to `duckdb/main`/`dev`). Once branch protection is enabled, the PR-only triggers are sufficient because `main` can only receive code via PRs anyway. Until branch protection lands, a direct push to `main` would skip CI — coordinate the admin step soon after this merges.
- Concurrency cancellation only affects in-flight runs for the *same* PR/branch; PRs from different source branches still run independently.
- Data/SDMX compatibility: none.
- Notes for release/changelog: drops `1.5.x` as a supported security line; `1.6.x` is now the LTS line alongside the latest minor.

## Notes

- Verified both YAML files parse with `yaml.safe_load`.
- Once this is merged and branch protection is configured, the maintainer should add the now-stable check names (`testing`, `Ubuntu 24.04 Tests`, `check-versions`) to **Required status checks** on the `main` and `1.6.X` rules, per the checklist in #697.

Closes #697