### PR TITLE
Add DuckDB db on disk execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtlengine"
-version = "1.7.0rc2"
+version = "1.7.0rc3"
 description = "Run and Validate VTL Scripts"
 license = "AGPL-3.0"
 readme = "README.md"

--- a/src/vtlengine/API/__init__.py
+++ b/src/vtlengine/API/__init__.py
@@ -2,7 +2,6 @@ import copy
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Union, cast
 
-import duckdb
 import pandas as pd
 from pysdmx.io.pd import PandasDataset
 from pysdmx.model import TransformationScheme
@@ -28,10 +27,7 @@ from vtlengine.AST.ASTConstructor import ASTVisitor
 from vtlengine.AST.ASTString import ASTString
 from vtlengine.AST.DAG import DAGAnalyzer
 from vtlengine.AST.Grammar._cpp_parser import vtl_cpp_parser
-from vtlengine.duckdb_transpiler.Config.config import (
-    configure_duckdb_connection,
-    configured_connection,
-)
+from vtlengine.duckdb_transpiler.Config.config import configured_connection
 from vtlengine.duckdb_transpiler.io import execute_queries, extract_datapoint_paths
 from vtlengine.duckdb_transpiler.Transpiler import SQLTranspiler
 from vtlengine.Exceptions import InputValidationException

--- a/src/vtlengine/API/__init__.py
+++ b/src/vtlengine/API/__init__.py
@@ -28,7 +28,10 @@ from vtlengine.AST.ASTConstructor import ASTVisitor
 from vtlengine.AST.ASTString import ASTString
 from vtlengine.AST.DAG import DAGAnalyzer
 from vtlengine.AST.Grammar._cpp_parser import vtl_cpp_parser
-from vtlengine.duckdb_transpiler.Config.config import configure_duckdb_connection
+from vtlengine.duckdb_transpiler.Config.config import (
+    configure_duckdb_connection,
+    configured_connection,
+)
 from vtlengine.duckdb_transpiler.io import execute_queries, extract_datapoint_paths
 from vtlengine.duckdb_transpiler.Transpiler import SQLTranspiler
 from vtlengine.Exceptions import InputValidationException
@@ -354,9 +357,7 @@ def _run_with_duckdb(
     output_folder_path = Path(output_folder) if output_folder else None
 
     # Create DuckDB connection and execute queries with DAG scheduling
-    conn = duckdb.connect()
-    configure_duckdb_connection(conn)
-    try:
+    with configured_connection() as conn:
         results = execute_queries(
             conn=conn,
             queries=queries,
@@ -370,8 +371,6 @@ def _run_with_duckdb(
             return_only_persistent=return_only_persistent,
             time_period_output_format=time_period_output_format,
         )
-    finally:
-        conn.close()
 
     # Applying output format (Date ISO 8601 T separator, TimePeriod representation)
     if output_folder_path is None:

--- a/src/vtlengine/__init__.py
+++ b/src/vtlengine/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     "validate_external_routine",
 ]
 
-__version__ = "1.7.0rc2"
+__version__ = "1.7.0rc3"

--- a/src/vtlengine/duckdb_transpiler/Config/config.py
+++ b/src/vtlengine/duckdb_transpiler/Config/config.py
@@ -130,6 +130,10 @@ MAX_TEMP_DIRECTORY_SIZE: str = os.getenv("VTL_MAX_TEMP_DIRECTORY_SIZE", "")
 # Use file-backed database instead of in-memory (better for large datasets)
 USE_IN_MEMORY_DB: bool = os.getenv("VTL_USE_IN_MEMORY_DB", "1").lower() in ("1", "true")
 
+# Minimum storage version required by the transpiler (typed macro parameters need >= v1.4.0).
+# DuckDB defaults to an older on-disk format for portability, so it must be set explicitly.
+STORAGE_COMPATIBILITY_VERSION: str = "v1.4.0"
+
 
 def get_memory_limit_bytes() -> int:
     """
@@ -223,7 +227,9 @@ def create_configured_connection(database: str = ":memory:") -> duckdb.DuckDBPyC
     Returns:
         Configured DuckDB connection
     """
-    conn = duckdb.connect(database)
+    conn = duckdb.connect(
+        database, config={"storage_compatibility_version": STORAGE_COMPATIBILITY_VERSION}
+    )
     configure_duckdb_connection(conn)
     return conn
 

--- a/src/vtlengine/duckdb_transpiler/Config/config.py
+++ b/src/vtlengine/duckdb_transpiler/Config/config.py
@@ -18,8 +18,12 @@ Example:
 """
 
 import os
+import shutil
 import tempfile
-from typing import Tuple, Union
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Tuple, Union
 
 import duckdb
 import psutil  # type: ignore[import-untyped]
@@ -124,7 +128,7 @@ TEMP_DIRECTORY: str = os.getenv("VTL_TEMP_DIRECTORY", tempfile.gettempdir())
 MAX_TEMP_DIRECTORY_SIZE: str = os.getenv("VTL_MAX_TEMP_DIRECTORY_SIZE", "")
 
 # Use file-backed database instead of in-memory (better for large datasets)
-USE_FILE_DATABASE: bool = os.getenv("VTL_USE_FILE_DATABASE", "").lower() in ("1", "true", "yes")
+USE_IN_MEMORY_DB: bool = os.getenv("VTL_USE_IN_MEMORY_DB", "1").lower() in ("1", "true")
 
 
 def get_memory_limit_bytes() -> int:
@@ -222,6 +226,27 @@ def create_configured_connection(database: str = ":memory:") -> duckdb.DuckDBPyC
     conn = duckdb.connect(database)
     configure_duckdb_connection(conn)
     return conn
+
+
+@contextmanager
+def configured_connection(database: str = ":memory:") -> Iterator[duckdb.DuckDBPyConnection]:
+    """Context manager that yields a configured DuckDB connection."""
+    Path(TEMP_DIRECTORY).mkdir(parents=True, exist_ok=True)
+    session_dir = Path(TEMP_DIRECTORY) / f"duckdb_tmp_{uuid.uuid4().hex}"
+    session_dir.mkdir(exist_ok=True)
+
+    if database == ":memory:" and not USE_IN_MEMORY_DB:
+        database = str(session_dir / "session.duckdb")
+
+    conn = create_configured_connection(database)
+    conn.execute(f"SET temp_directory = '{session_dir}'")
+    try:
+        yield conn
+    finally:
+        try:
+            conn.close()
+        finally:
+            shutil.rmtree(session_dir, ignore_errors=True)
 
 
 def get_system_info() -> dict[str, Union[float, int, str, None]]:


### PR DESCRIPTION
## Summary

Added `VTL_IN_MEMORY_DB` env var to allow execution with db on disk (True `:memory:` database. False `$TEMP_DIRECTORY/duckdb_tmp_{uuid.uuid4().hex}/session.duckdb`).

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)
