### PR TITLE
Fix #716: Read DuckDB env vars lazily at run time

### DIFF
--- a/src/vtlengine/duckdb_transpiler/Config/config.py
+++ b/src/vtlengine/duckdb_transpiler/Config/config.py
@@ -118,20 +118,31 @@ def set_decimal_config() -> None:
 # Memory & Performance Configuration
 # =============================================================================
 
-# Default memory limit (80% of system RAM)
-MEMORY_LIMIT: str = os.getenv("VTL_MEMORY_LIMIT", "80%")
+# Accessor functions read os.environ on every call so user scripts can mutate
+# os.environ after `import vtlengine` and have those values take effect on the
+# next run(). Capturing them in module-level constants would freeze the values
+# at import time.
 
-# Default thread count (default = 1)
-THREADS: int = int(os.getenv("VTL_THREADS", "1"))
 
-# Temp directory for spill-to-disk
-TEMP_DIRECTORY: str = os.getenv("VTL_TEMP_DIRECTORY", tempfile.gettempdir())
+def _memory_limit() -> str:
+    return os.getenv("VTL_MEMORY_LIMIT", "80%")
 
-# Max temp directory size for spill-to-disk (empty = use available disk space)
-MAX_TEMP_DIRECTORY_SIZE: str = os.getenv("VTL_MAX_TEMP_DIRECTORY_SIZE", "")
 
-# Use file-backed database instead of in-memory (better for large datasets)
-USE_IN_MEMORY_DB: bool = os.getenv("VTL_USE_IN_MEMORY_DB", "1").lower() in ("1", "true")
+def _threads() -> int:
+    return int(os.getenv("VTL_THREADS", "1"))
+
+
+def _temp_directory() -> str:
+    return os.getenv("VTL_TEMP_DIRECTORY", tempfile.gettempdir())
+
+
+def _max_temp_directory_size() -> str:
+    return os.getenv("VTL_MAX_TEMP_DIRECTORY_SIZE", "")
+
+
+def _use_in_memory_db() -> bool:
+    return os.getenv("VTL_USE_IN_MEMORY_DB", "1").lower() in ("1", "true")
+
 
 # Minimum storage version required by the transpiler (typed macro parameters need >= v1.4.0).
 # DuckDB defaults to an older on-disk format for portability, so it must be set explicitly.
@@ -150,7 +161,7 @@ def get_memory_limit_bytes() -> int:
     Returns:
         Memory limit in bytes
     """
-    limit = MEMORY_LIMIT.strip().upper()
+    limit = _memory_limit().strip().upper()
 
     total_ram = psutil.virtual_memory().total
 
@@ -202,17 +213,17 @@ def configure_duckdb_connection(conn: duckdb.DuckDBPyConnection) -> None:
         and data structures to speed up repeated queries
     - Set decimal configuration: Apply the configured decimal precision and scale
     """
+    max_temp_dir_size = _max_temp_directory_size()
     statements = [
         f"SET memory_limit = '{get_memory_limit_str()}'",
-        f"SET temp_directory = '{TEMP_DIRECTORY}'",
+        f"SET temp_directory = '{_temp_directory()}'",
         "SET preserve_insertion_order = false",
         "SET max_expression_depth TO 10000",
         "SET enable_object_cache = true",
+        f"SET threads = {_threads()}",
     ]
-    if MAX_TEMP_DIRECTORY_SIZE:
-        statements.append(f"SET max_temp_directory_size = '{MAX_TEMP_DIRECTORY_SIZE}'")
-    if THREADS is not None:
-        statements.append(f"SET threads = {THREADS}")
+    if max_temp_dir_size:
+        statements.append(f"SET max_temp_directory_size = '{max_temp_dir_size}'")
 
     conn.execute(";\n".join(statements))
 
@@ -240,11 +251,12 @@ def create_configured_connection(database: str = ":memory:") -> duckdb.DuckDBPyC
 @contextmanager
 def configured_connection(database: str = ":memory:") -> Iterator[duckdb.DuckDBPyConnection]:
     """Context manager that yields a configured DuckDB connection."""
-    Path(TEMP_DIRECTORY).mkdir(parents=True, exist_ok=True)
-    session_dir = Path(TEMP_DIRECTORY) / f"duckdb_tmp_{uuid.uuid4().hex}"
+    temp_dir = _temp_directory()
+    Path(temp_dir).mkdir(parents=True, exist_ok=True)
+    session_dir = Path(temp_dir) / f"duckdb_tmp_{uuid.uuid4().hex}"
     session_dir.mkdir(exist_ok=True)
 
-    if database == ":memory:" and not USE_IN_MEMORY_DB:
+    if database == ":memory:" and not _use_in_memory_db():
         database = str(session_dir / "session.duckdb")
 
     conn = create_configured_connection(database)
@@ -272,6 +284,6 @@ def get_system_info() -> dict[str, Union[float, int, str, None]]:
         "used_percent": mem.percent,
         "configured_limit_gb": get_memory_limit_bytes() / (1024**3),
         "configured_limit_str": get_memory_limit_str(),
-        "threads": THREADS or os.cpu_count(),
-        "temp_directory": TEMP_DIRECTORY,
+        "threads": _threads() or os.cpu_count(),
+        "temp_directory": _temp_directory(),
     }

--- a/src/vtlengine/duckdb_transpiler/io/_io.py
+++ b/src/vtlengine/duckdb_transpiler/io/_io.py
@@ -33,12 +33,10 @@ from vtlengine.files.sdmx_handler import (
 )
 from vtlengine.Model import Component, Dataset, Role, Scalar
 
-# Environment variable to skip post-load validations (for benchmarking)
-SKIP_LOAD_VALIDATION = os.environ.get("VTL_SKIP_LOAD_VALIDATION", "").lower() in (
-    "1",
-    "true",
-    "yes",
-)
+
+def _skip_load_validation() -> bool:
+    """Read VTL_SKIP_LOAD_VALIDATION lazily so mutations after import take effect."""
+    return os.environ.get("VTL_SKIP_LOAD_VALIDATION", "").lower() in ("1", "true", "yes")
 
 
 def _validate_loaded_table(
@@ -60,7 +58,7 @@ def _validate_loaded_table(
     # Normalize TimePeriod columns to canonical internal representation
     _normalize_time_period_columns(conn, table_name, components)
 
-    if SKIP_LOAD_VALIDATION:
+    if _skip_load_validation():
         return
 
     try:

--- a/tests/duckdb_transpiler/test_env_var_lazy.py
+++ b/tests/duckdb_transpiler/test_env_var_lazy.py
@@ -1,0 +1,89 @@
+"""
+Tests that DuckDB configuration env vars are read lazily — i.e. mutations
+to ``os.environ`` made after importing ``vtlengine`` take effect on the
+next call into the engine.
+
+Before the fix, ``VTL_MEMORY_LIMIT``, ``VTL_THREADS``,
+``VTL_TEMP_DIRECTORY``, ``VTL_MAX_TEMP_DIRECTORY_SIZE``,
+``VTL_USE_IN_MEMORY_DB`` and ``VTL_SKIP_LOAD_VALIDATION`` were captured at
+module import time and could not be overridden from a user script.
+"""
+
+import os
+from unittest import mock
+
+import duckdb
+
+from vtlengine.duckdb_transpiler.Config import config as cfg
+from vtlengine.duckdb_transpiler.io import _io as io_mod
+
+
+def test_memory_limit_accessor_reads_env_each_call() -> None:
+    with mock.patch.dict(os.environ, {"VTL_MEMORY_LIMIT": "2GB"}, clear=False):
+        assert cfg._memory_limit() == "2GB"
+    with mock.patch.dict(os.environ, {"VTL_MEMORY_LIMIT": "5GB"}, clear=False):
+        assert cfg._memory_limit() == "5GB"
+
+
+def test_threads_accessor_reads_env_each_call() -> None:
+    with mock.patch.dict(os.environ, {"VTL_THREADS": "3"}, clear=False):
+        assert cfg._threads() == 3
+    with mock.patch.dict(os.environ, {"VTL_THREADS": "7"}, clear=False):
+        assert cfg._threads() == 7
+
+
+def test_threads_accessor_default() -> None:
+    env = {k: v for k, v in os.environ.items() if k != "VTL_THREADS"}
+    with mock.patch.dict(os.environ, env, clear=True):
+        assert cfg._threads() == 1
+
+
+def test_temp_directory_accessor_reads_env_each_call(tmp_path: object) -> None:
+    p = str(tmp_path)
+    with mock.patch.dict(os.environ, {"VTL_TEMP_DIRECTORY": p}, clear=False):
+        assert cfg._temp_directory() == p
+
+
+def test_max_temp_directory_size_accessor_reads_env_each_call() -> None:
+    with mock.patch.dict(os.environ, {"VTL_MAX_TEMP_DIRECTORY_SIZE": "10GB"}, clear=False):
+        assert cfg._max_temp_directory_size() == "10GB"
+
+
+def test_use_in_memory_db_accessor_reads_env_each_call() -> None:
+    with mock.patch.dict(os.environ, {"VTL_USE_IN_MEMORY_DB": "0"}, clear=False):
+        assert cfg._use_in_memory_db() is False
+    with mock.patch.dict(os.environ, {"VTL_USE_IN_MEMORY_DB": "1"}, clear=False):
+        assert cfg._use_in_memory_db() is True
+
+
+def test_skip_load_validation_accessor_reads_env_each_call() -> None:
+    with mock.patch.dict(os.environ, {"VTL_SKIP_LOAD_VALIDATION": "1"}, clear=False):
+        assert io_mod._skip_load_validation() is True
+    with mock.patch.dict(os.environ, {"VTL_SKIP_LOAD_VALIDATION": "0"}, clear=False):
+        assert io_mod._skip_load_validation() is False
+
+
+def test_configure_duckdb_connection_applies_post_import_env() -> None:
+    """Integration check: env vars mutated AFTER import flow through to DuckDB."""
+    env = {
+        "VTL_MEMORY_LIMIT": "2GB",
+        "VTL_THREADS": "3",
+    }
+    with mock.patch.dict(os.environ, env, clear=False):
+        conn = duckdb.connect(":memory:")
+        try:
+            cfg.configure_duckdb_connection(conn)
+            settings = dict(
+                conn.execute(
+                    "SELECT name, value FROM duckdb_settings() "
+                    "WHERE name IN ('memory_limit', 'threads')"
+                ).fetchall()
+            )
+        finally:
+            conn.close()
+
+    assert settings["threads"] == "3"
+    # DuckDB normalises memory_limit to a human-readable form; just check
+    # the value is in the right ballpark for 2GB (it reports ~1.8 GiB after
+    # reserving overhead). The threads check above is the authoritative one.
+    assert "GiB" in settings["memory_limit"] or "MiB" in settings["memory_limit"]


### PR DESCRIPTION
## Summary

Fixes #716. Six DuckDB-related env vars were read into module-level constants when `duckdb_transpiler.Config.config` (or `duckdb_transpiler.io._io`) was first imported, so mutations to `os.environ` from user code after `import vtlengine` were silently ignored. Replace each module-level capture with a small accessor function that reads `os.environ` on every call.

Affected variables:

- `VTL_MEMORY_LIMIT`, `VTL_THREADS`, `VTL_TEMP_DIRECTORY`, `VTL_MAX_TEMP_DIRECTORY_SIZE`, `VTL_USE_IN_MEMORY_DB` (in `config.py`)
- `VTL_SKIP_LOAD_VALIDATION` (in `_io.py`)

`VTL_DUCKDB_DECIMAL_WIDTH` and `OUTPUT_NUMBER_SIGNIFICANT_DIGITS` were already lazy and remain unchanged.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest` — 4882 passed, 27 skipped)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- **Breaking changes?** No. The removed module-level names (`MEMORY_LIMIT`, `THREADS`, `TEMP_DIRECTORY`, `MAX_TEMP_DIRECTORY_SIZE`, `USE_IN_MEMORY_DB`, `SKIP_LOAD_VALIDATION`) are not re-exported anywhere and not referenced outside the modules where they were defined (verified by repo-wide grep).
- **Data/SDMX compatibility:** None.
- **Behavior changes:** Previously dead branch `if THREADS is not None` was dropped (the accessor always returns `int`). Existing tests cover the behavior end-to-end.
- **Notes for release/changelog:** Worth flagging in the changelog under "Bug fixes" — users who set env vars in Python code instead of the shell will get correct behavior for the first time.

## Notes

- Added `tests/duckdb_transpiler/test_env_var_lazy.py` (8 tests) covering each accessor individually plus one integration check that mutates env after import and reads back from `duckdb_settings()`.
- Follow-up worth doing separately: document the env-var precedence in `docs/environment_variables.rst` (when shell env vs Python `os.environ` mutations take effect). Intentionally not in this PR.
