### PR TITLE
Fix #719: Github Workflow C++ parser cache overrides py files changes

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,11 +38,13 @@ jobs:
         with:
           path: build/antlr4-prefix
           key: antlr4-runtime-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('scripts/setup_antlr4_runtime.sh', 'CMakeLists.txt') }}
-      - name: Cache C++ parser wheel
+      - name: Cache compiled C++ parser
         uses: actions/cache@v4
         id: cpp-cache
         with:
-          path: .cpp-wheel
+          # Just the compiled extension binary — restoring it puts it back
+          # next to its __init__.py with no .py files riding along.
+          path: src/vtlengine/AST/Grammar/_cpp_parser/vtl_cpp_parser*
           key: cpp-parser-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('src/vtlengine/AST/Grammar/_cpp_parser/**', 'CMakeLists.txt', 'pyproject.toml') }}
       - name: Download ANTLR4 C++ runtime source
         if: steps.cpp-cache.outputs.cache-hit != 'true' && steps.antlr4-cache.outputs.cache-hit != 'true'
@@ -68,18 +70,22 @@ jobs:
           fi
           cmake --build build/antlr4-build --target antlr4_runtime --config Release
           cmake --install build/antlr4-build --prefix "$PWD/build/antlr4-prefix" --config Release
-      - name: Build C++ parser wheel
+      - name: Build C++ parser binary
         if: steps.cpp-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          pip wheel . -w .cpp-wheel --no-deps -v \
+          # Build the wheel only to fish out the compiled extension; throw
+          # the rest away. The cached entry above is just the binary.
+          pip wheel . -w .build_wheel --no-deps -v \
             -C cmake.define.VTLENGINE_USE_PREBUILT_ANTLR4=ON \
             -C "cmake.define.VTLENGINE_ANTLR4_PREFIX=$PWD/build/antlr4-prefix"
-      - name: Install package and dependencies
-        run: |
-          poetry install --no-root --all-extras
-          poetry run pip install --force-reinstall --no-deps .cpp-wheel/*.whl
+          unzip -o -j .build_wheel/*.whl \
+            'vtlengine/AST/Grammar/_cpp_parser/vtl_cpp_parser*' \
+            -d src/vtlengine/AST/Grammar/_cpp_parser/
+          rm -rf .build_wheel
+      - name: Install dependencies
         shell: bash
+        run: poetry install --no-root --all-extras
       - name: Check compliance with code formatting guidelines
         run: poetry run ruff format --no-cache --check
       - name: Run lint checks

--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -26,12 +26,14 @@ jobs:
           path: build/antlr4-prefix
           key: antlr4-runtime-ubuntu2404-py3.12-${{ hashFiles('scripts/setup_antlr4_runtime.sh', 'CMakeLists.txt') }}
 
-      - name: Cache C++ parser wheel
+      - name: Cache compiled C++ parser
         uses: actions/cache@v4
         id: cpp-cache
         with:
-          path: .cpp-wheel
-          key: cpp-parser-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('src/vtlengine/AST/Grammar/_cpp_parser/**', 'CMakeLists.txt', 'pyproject.toml') }}
+          # Just the compiled extension binary — restoring it puts it back
+          # next to its __init__.py with no .py files riding along.
+          path: src/vtlengine/AST/Grammar/_cpp_parser/vtl_cpp_parser*
+          key: cpp-parser-ubuntu2404-py3.12-${{ hashFiles('src/vtlengine/AST/Grammar/_cpp_parser/**', 'CMakeLists.txt', 'pyproject.toml') }}
 
       - name: Install system dependencies
         run: |
@@ -76,17 +78,18 @@ jobs:
           cmake --build build/antlr4-build --target antlr4_runtime --config Release
           cmake --install build/antlr4-build --prefix "$PWD/build/antlr4-prefix" --config Release
 
-      - name: Build C++ parser wheel
+      - name: Build C++ parser binary
         if: steps.cpp-cache.outputs.cache-hit != 'true'
         run: |
-          pip wheel . -w .cpp-wheel --no-deps -v \
+          pip wheel . -w .build_wheel --no-deps -v \
             -C cmake.define.VTLENGINE_USE_PREBUILT_ANTLR4=ON \
             -C "cmake.define.VTLENGINE_ANTLR4_PREFIX=$PWD/build/antlr4-prefix"
+          unzip -o -j .build_wheel/*.whl \
+            'vtlengine/AST/Grammar/_cpp_parser/vtl_cpp_parser*' \
+            -d src/vtlengine/AST/Grammar/_cpp_parser/
+          rm -rf .build_wheel
         env:
           PIP_BREAK_SYSTEM_PACKAGES: "1"
-
-      - name: Install C++ parser
-        run: pip install --break-system-packages --no-deps .cpp-wheel/*.whl
 
       - name: Run tests (pandas backend)
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ follow_imports = "silent"
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
+pythonpath = ["src"]
 markers = [
     "input_path: directory where tests data files are stored"
 ]


### PR DESCRIPTION
## Summary

Now only the parsers binary is cached.
Pytest pythonpath is now set to `src` to execute with the updated py files.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)
