### PR TITLE
Fix #724: Raise VTLSyntaxError instead of crashing on malformed VTL

### DIFF
--- a/src/vtlengine/API/__init__.py
+++ b/src/vtlengine/API/__init__.py
@@ -30,7 +30,7 @@ from vtlengine.AST.Grammar._cpp_parser import vtl_cpp_parser
 from vtlengine.duckdb_transpiler.Config.config import configured_connection
 from vtlengine.duckdb_transpiler.io import execute_queries, extract_datapoint_paths
 from vtlengine.duckdb_transpiler.Transpiler import SQLTranspiler
-from vtlengine.Exceptions import InputValidationException
+from vtlengine.Exceptions import InputValidationException, VTLSyntaxError
 from vtlengine.files.output import format_date_iso8601
 from vtlengine.files.output._time_period_representation import (
     TimePeriodRepresentation,
@@ -90,6 +90,15 @@ def create_ast(text: str) -> Start:
     """
     text = text + "\n"
     cst = vtl_cpp_parser.parse(text)
+    errors = vtl_cpp_parser.get_syntax_errors()
+    if errors:
+        first = errors[0]
+        raise VTLSyntaxError(
+            "0-1-4-1",
+            line=first["line"],
+            column=first["column"] + 1,
+            detail=first["message"],
+        )
     visitor = ASTVisitor()
     ast = visitor.visitStart(cst)
     DAGAnalyzer.create_dag(ast)

--- a/src/vtlengine/AST/Grammar/_cpp_parser/bindings.cpp
+++ b/src/vtlengine/AST/Grammar/_cpp_parser/bindings.cpp
@@ -348,9 +348,45 @@ struct ParserState {
         int column;
     };
     std::vector<CommentInfo> comments;
+
+    struct SyntaxErrorInfo {
+        int line;
+        int column;
+        std::string message;
+        std::string offending_text;
+    };
+    std::vector<SyntaxErrorInfo> syntax_errors;
 };
 
 static ParserState g_state;
+
+
+// ============================================================
+// CollectingErrorListener: captures syntax errors instead of
+// printing them to stderr. Reads from g_state.syntax_errors.
+// ============================================================
+class CollectingErrorListener : public antlr4::BaseErrorListener {
+public:
+    void syntaxError(antlr4::Recognizer* /*recognizer*/,
+                     antlr4::Token* offendingSymbol,
+                     size_t line,
+                     size_t charPositionInLine,
+                     const std::string& msg,
+                     std::exception_ptr /*e*/) override {
+        std::string text;
+        if (offendingSymbol) {
+            text = offendingSymbol->getText();
+        }
+        g_state.syntax_errors.push_back({
+            static_cast<int>(line),
+            static_cast<int>(charPositionInLine),
+            msg,
+            text
+        });
+    }
+};
+
+static CollectingErrorListener g_collecting_listener;
 
 
 // ============================================================
@@ -479,6 +515,7 @@ static py::object do_parse(const std::string& text) {
 
     g_state.input_text = text;
     g_state.comments.clear();
+    g_state.syntax_errors.clear();
 
     g_state.input = std::make_unique<antlr4::ANTLRInputStream>(text);
     g_state.lexer = std::make_unique<VtlLexer>(g_state.input.get());
@@ -489,8 +526,12 @@ static py::object do_parse(const std::string& text) {
     g_state.parser->getInterpreter<antlr4::atn::ParserATNSimulator>()
         ->setPredictionMode(antlr4::atn::PredictionMode::SLL);
 
-    // Remove default error listeners for cleaner output
+    // Replace default error listeners (which print to stderr) with the
+    // collecting listener so Python can surface a clean error.
+    g_state.lexer->removeErrorListeners();
+    g_state.lexer->addErrorListener(&g_collecting_listener);
     g_state.parser->removeErrorListeners();
+    g_state.parser->addErrorListener(&g_collecting_listener);
 
     // Parse
     auto* tree = g_state.parser->start();
@@ -515,6 +556,19 @@ static py::object do_parse(const std::string& text) {
 
 static std::string get_input_text() {
     return g_state.input_text;
+}
+
+static py::list get_syntax_errors() {
+    py::list result;
+    for (auto& e : g_state.syntax_errors) {
+        py::dict d;
+        d["line"] = e.line;
+        d["column"] = e.column;
+        d["message"] = e.message;
+        d["offending_text"] = e.offending_text;
+        result.append(d);
+    }
+    return result;
 }
 
 static py::list get_comments() {
@@ -563,6 +617,8 @@ PYBIND11_MODULE(vtl_cpp_parser, m) {
           "Get the input text from the last parse() call");
     m.def("get_comments", &get_comments,
           "Get comment tokens from the last parse() call");
+    m.def("get_syntax_errors", &get_syntax_errors,
+          "Get syntax errors collected during the last parse() call");
 
     // Token type constants
     m.attr("LPAREN") = static_cast<int>(VtlParser::LPAREN);

--- a/src/vtlengine/Exceptions/__init__.py
+++ b/src/vtlengine/Exceptions/__init__.py
@@ -80,6 +80,21 @@ class RunTimeError(VTLEngineException):
             self.comp_code = comp_code
 
 
+class VTLSyntaxError(VTLEngineException):
+    """Raised when the VTL script cannot be parsed because it does not match the grammar."""
+
+    def __init__(self, code: str, **kwargs: Any) -> None:
+        message = centralised_messages[code]["message"].format(**kwargs)
+        line = kwargs.get("line")
+        column = kwargs.get("column")
+        super().__init__(
+            message,
+            lino=None if line is None else str(line),
+            colno=None if column is None else str(column),
+            code=code,
+        )
+
+
 class InputValidationException(VTLEngineException):
     """ """
 

--- a/src/vtlengine/Exceptions/messages.py
+++ b/src/vtlengine/Exceptions/messages.py
@@ -226,6 +226,12 @@ centralised_messages = {
         "description": "Raised when URL datapoints are provided but data_structures is not a "
         "file path or URL for fetching the SDMX structure definition.",
     },
+    # VTL parser errors
+    "0-1-4-1": {
+        "message": "VTL syntax error at line {line}, column {column}: {detail}",
+        "description": "Raised when the VTL script cannot be parsed because it does not "
+        "match the VTL grammar (e.g. using '=' instead of ':=' in a calc clause).",
+    },
     # Env var errors
     "0-4-1-1": {
         "message": "Invalid value for {env_var}: {value}. "


### PR DESCRIPTION
## Summary

- Replace silent `removeErrorListeners()` in the C++ binding with a `CollectingErrorListener` that captures ANTLR syntax errors.
- Surface them in Python: `create_ast()` checks `get_syntax_errors()` and raises the new `VTLSyntaxError` (error code `0-1-4-1`) with the offending line and column before the AST visitor runs.
- Eliminates the `AttributeError: 'TerminalNode' object has no attribute 'children'` crash that previously masked the real problem.

Before:
```
AttributeError: 'TerminalNode' object has no attribute 'children'
```
After:
```
VTLSyntaxError: VTL syntax error at line 1, column 26: mismatched input '=' expecting ':='
```

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable) — N/A; new error codes are auto-included in `docs/error_messages.rst`.

## Impact / Risk

- **Public API**: adds `VTLSyntaxError` under `vtlengine.Exceptions`. Existing callers catching `Exception` keep working; no caller is expected to rely on the prior `AttributeError`.
- **C++ binding**: rebuild required (wheel builds pick this up automatically; no surface change on the C++ side).
- **Behaviour**: parser errors are now raised eagerly at parse time. No change for valid VTL.

## Notes

The original investigation also surfaced a separate bug: `max(<identifier> over(partition by ...))` silently returns the original column instead of computing the max — caused by a duplicated-name column in DuckDB (`VALPAR` / `VALPAR_1`). Not addressed in this PR; will be filed separately.

Fixes #724