### PR TITLE
Fix #726: Source-line preview and token-underline caret in VTLSyntaxError

### DIFF
--- a/src/vtlengine/API/__init__.py
+++ b/src/vtlengine/API/__init__.py
@@ -94,10 +94,11 @@ def create_ast(text: str) -> Start:
     if errors:
         first = errors[0]
         raise VTLSyntaxError(
-            "0-1-4-1",
             line=first["line"],
             column=first["column"] + 1,
             detail=first["message"],
+            source_line=first["source_line"],
+            underline_length=first["underline_length"],
         )
     visitor = ASTVisitor()
     ast = visitor.visitStart(cst)

--- a/src/vtlengine/API/__init__.py
+++ b/src/vtlengine/API/__init__.py
@@ -90,15 +90,14 @@ def create_ast(text: str) -> Start:
     """
     text = text + "\n"
     cst = vtl_cpp_parser.parse(text)
-    errors = vtl_cpp_parser.get_syntax_errors()
-    if errors:
-        first = errors[0]
+    error = vtl_cpp_parser.get_syntax_error()
+    if error is not None:
         raise VTLSyntaxError(
-            line=first["line"],
-            column=first["column"] + 1,
-            detail=first["message"],
-            source_line=first["source_line"],
-            underline_length=first["underline_length"],
+            line=error["line"],
+            column=error["column"] + 1,
+            detail=error["message"],
+            source_line=error["source_line"],
+            underline_length=error["underline_length"],
         )
     visitor = ASTVisitor()
     ast = visitor.visitStart(cst)

--- a/src/vtlengine/AST/Grammar/_cpp_parser/bindings.cpp
+++ b/src/vtlengine/AST/Grammar/_cpp_parser/bindings.cpp
@@ -18,6 +18,7 @@
 #include "VtlParser.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <typeindex>
 #include <unordered_map>
@@ -357,7 +358,7 @@ struct ParserState {
         std::string source_line;
         int underline_length;
     };
-    std::vector<SyntaxErrorInfo> syntax_errors;
+    std::optional<SyntaxErrorInfo> syntax_error;
 };
 
 static ParserState g_state;
@@ -413,8 +414,9 @@ static std::string extract_source_line_expanded(int line_1based, int& column_in_
 
 
 // ============================================================
-// CollectingErrorListener: captures syntax errors instead of
-// printing them to stderr. Reads from g_state.syntax_errors.
+// CollectingErrorListener: captures the first syntax error instead
+// of printing to stderr. Subsequent errors from ANTLR's error
+// recovery are usually noise, so we ignore them.
 // ============================================================
 class CollectingErrorListener : public antlr4::BaseErrorListener {
 public:
@@ -424,6 +426,8 @@ public:
                      size_t charPositionInLine,
                      const std::string& msg,
                      std::exception_ptr /*e*/) override {
+        if (g_state.syntax_error.has_value()) return;
+
         std::string text;
         int underline_length = 1;
         if (offendingSymbol) {
@@ -441,14 +445,14 @@ public:
         std::string src_line = extract_source_line_expanded(
             static_cast<int>(line), column_1based);
 
-        g_state.syntax_errors.push_back({
+        g_state.syntax_error = ParserState::SyntaxErrorInfo{
             static_cast<int>(line),
             column_1based - 1,    // store 0-based for back-compat with Python; API adds 1.
             msg,
             text,
             src_line,
             underline_length
-        });
+        };
     }
 };
 
@@ -581,7 +585,7 @@ static py::object do_parse(const std::string& text) {
 
     g_state.input_text = text;
     g_state.comments.clear();
-    g_state.syntax_errors.clear();
+    g_state.syntax_error.reset();
 
     g_state.input = std::make_unique<antlr4::ANTLRInputStream>(text);
     g_state.lexer = std::make_unique<VtlLexer>(g_state.input.get());
@@ -624,19 +628,19 @@ static std::string get_input_text() {
     return g_state.input_text;
 }
 
-static py::list get_syntax_errors() {
-    py::list result;
-    for (auto& e : g_state.syntax_errors) {
-        py::dict d;
-        d["line"] = e.line;
-        d["column"] = e.column;
-        d["message"] = e.message;
-        d["offending_text"] = e.offending_text;
-        d["source_line"] = e.source_line;
-        d["underline_length"] = e.underline_length;
-        result.append(d);
+static py::object get_syntax_error() {
+    if (!g_state.syntax_error.has_value()) {
+        return py::none();
     }
-    return result;
+    auto& e = g_state.syntax_error.value();
+    py::dict d;
+    d["line"] = e.line;
+    d["column"] = e.column;
+    d["message"] = e.message;
+    d["offending_text"] = e.offending_text;
+    d["source_line"] = e.source_line;
+    d["underline_length"] = e.underline_length;
+    return d;
 }
 
 static py::list get_comments() {
@@ -685,8 +689,8 @@ PYBIND11_MODULE(vtl_cpp_parser, m) {
           "Get the input text from the last parse() call");
     m.def("get_comments", &get_comments,
           "Get comment tokens from the last parse() call");
-    m.def("get_syntax_errors", &get_syntax_errors,
-          "Get syntax errors collected during the last parse() call");
+    m.def("get_syntax_error", &get_syntax_error,
+          "Get the first syntax error from the last parse() call, or None if there were none");
 
     // Token type constants
     m.attr("LPAREN") = static_cast<int>(VtlParser::LPAREN);

--- a/src/vtlengine/AST/Grammar/_cpp_parser/bindings.cpp
+++ b/src/vtlengine/AST/Grammar/_cpp_parser/bindings.cpp
@@ -354,11 +354,62 @@ struct ParserState {
         int column;
         std::string message;
         std::string offending_text;
+        std::string source_line;
+        int underline_length;
     };
     std::vector<SyntaxErrorInfo> syntax_errors;
 };
 
 static ParserState g_state;
+
+
+// ============================================================
+// Helper: extract one line (1-based) from the input buffer, with
+// each \t expanded to TAB_WIDTH spaces. Adjusts the caller-supplied
+// column so the caret stays aligned after tab expansion.
+// ============================================================
+static constexpr int TAB_WIDTH = 4;
+
+static std::string extract_source_line_expanded(int line_1based, int& column_in_out) {
+    const std::string& src = g_state.input_text;
+    if (line_1based < 1) return "";
+
+    // Find start of the requested line.
+    size_t start = 0;
+    int current_line = 1;
+    while (current_line < line_1based && start < src.size()) {
+        if (src[start] == '\n') {
+            ++current_line;
+        }
+        ++start;
+    }
+    if (current_line != line_1based) return "";
+
+    // Walk to end of the requested line, expanding tabs and tracking the
+    // caller's column index (1-based, counted in original-source columns).
+    std::string out;
+    int orig_col = 1;        // 1-based original column index walking the source
+    int target_col = column_in_out;  // 1-based original column we want to remap
+    int remapped = target_col;       // 1-based output column after tab expansion
+    for (size_t i = start; i < src.size() && src[i] != '\n'; ++i) {
+        char c = src[i];
+        if (orig_col == target_col) {
+            remapped = static_cast<int>(out.size()) + 1;
+        }
+        if (c == '\t') {
+            out.append(TAB_WIDTH, ' ');
+        } else if (c != '\r') {
+            out.push_back(c);
+        }
+        ++orig_col;
+    }
+    // Caret past end of line: snap to end.
+    if (target_col > orig_col) {
+        remapped = static_cast<int>(out.size()) + 1;
+    }
+    column_in_out = remapped;
+    return out;
+}
 
 
 // ============================================================
@@ -374,14 +425,29 @@ public:
                      const std::string& msg,
                      std::exception_ptr /*e*/) override {
         std::string text;
+        int underline_length = 1;
         if (offendingSymbol) {
             text = offendingSymbol->getText();
+            size_t start_idx = offendingSymbol->getStartIndex();
+            size_t stop_idx = offendingSymbol->getStopIndex();
+            if (stop_idx != static_cast<size_t>(-1) && stop_idx >= start_idx) {
+                underline_length = static_cast<int>(stop_idx - start_idx + 1);
+            }
         }
+
+        // ANTLR uses 0-based columns; we use 1-based externally. The helper
+        // rewrites the column to account for tab expansion.
+        int column_1based = static_cast<int>(charPositionInLine) + 1;
+        std::string src_line = extract_source_line_expanded(
+            static_cast<int>(line), column_1based);
+
         g_state.syntax_errors.push_back({
             static_cast<int>(line),
-            static_cast<int>(charPositionInLine),
+            column_1based - 1,    // store 0-based for back-compat with Python; API adds 1.
             msg,
-            text
+            text,
+            src_line,
+            underline_length
         });
     }
 };
@@ -566,6 +632,8 @@ static py::list get_syntax_errors() {
         d["column"] = e.column;
         d["message"] = e.message;
         d["offending_text"] = e.offending_text;
+        d["source_line"] = e.source_line;
+        d["underline_length"] = e.underline_length;
         result.append(d);
     }
     return result;

--- a/src/vtlengine/Exceptions/__init__.py
+++ b/src/vtlengine/Exceptions/__init__.py
@@ -83,16 +83,20 @@ class RunTimeError(VTLEngineException):
 class VTLSyntaxError(VTLEngineException):
     """Raised when the VTL script cannot be parsed because it does not match the grammar."""
 
-    def __init__(self, code: str, **kwargs: Any) -> None:
-        message = centralised_messages[code]["message"].format(**kwargs)
-        line = kwargs.get("line")
-        column = kwargs.get("column")
-        super().__init__(
-            message,
-            lino=None if line is None else str(line),
-            colno=None if column is None else str(column),
-            code=code,
-        )
+    def __init__(
+        self,
+        *,
+        line: int,
+        column: int,
+        detail: str,
+        source_line: str = "",
+        underline_length: int = 1,
+    ) -> None:
+        message = f"VTL syntax error at line {line}, column {column}: {detail}"
+        if source_line:
+            caret = " " * (column - 1) + "^" * max(1, underline_length)
+            message += f"\n    {source_line}\n    {caret}"
+        super().__init__(message, lino=str(line), colno=str(column))
 
 
 class InputValidationException(VTLEngineException):

--- a/src/vtlengine/Exceptions/messages.py
+++ b/src/vtlengine/Exceptions/messages.py
@@ -226,12 +226,6 @@ centralised_messages = {
         "description": "Raised when URL datapoints are provided but data_structures is not a "
         "file path or URL for fetching the SDMX structure definition.",
     },
-    # VTL parser errors
-    "0-1-4-1": {
-        "message": "VTL syntax error at line {line}, column {column}: {detail}",
-        "description": "Raised when the VTL script cannot be parsed because it does not "
-        "match the VTL grammar (e.g. using '=' instead of ':=' in a calc clause).",
-    },
     # Env var errors
     "0-4-1-1": {
         "message": "Invalid value for {env_var}: {value}. "

--- a/tests/API/test_syntax_errors.py
+++ b/tests/API/test_syntax_errors.py
@@ -1,0 +1,89 @@
+import pandas as pd
+import pytest
+
+from vtlengine import run
+from vtlengine.Exceptions import VTLSyntaxError
+
+_EMPTY_DS = {"datasets": []}
+_NO_DATA: dict[str, pd.DataFrame] = {}
+
+
+def test_single_char_offending_token_has_caret_at_column():
+    """`=` used in place of `:=` in a calc clause — caret points at the `=`."""
+    script = "DS_A <- DS_1[calc test_2 = 42];"
+    with pytest.raises(VTLSyntaxError) as ex:
+        run(script=script, data_structures=_EMPTY_DS, datapoints=_NO_DATA)
+
+    msg = str(ex.value)
+    assert "line 1, column 26" in msg
+    assert "DS_A <- DS_1[calc test_2 = 42];" in msg
+    # 4-space indent + 25 spaces before column 26 → caret at offset 4 + 25 = 29
+    assert "\n" + " " * 29 + "^" in msg
+    # Single-character offending token = single caret
+    assert "^^" not in msg
+
+
+def test_multi_char_offending_token_is_fully_underlined():
+    """A multi-character offending identifier gets a `^^^...` underline matching its length."""
+    script = "DS_A := DS_1[calc x foo_bar 5];"
+    with pytest.raises(VTLSyntaxError) as ex:
+        run(script=script, data_structures=_EMPTY_DS, datapoints=_NO_DATA)
+
+    msg = str(ex.value)
+    assert "foo_bar" in msg
+    # 7-character token → 7 carets
+    assert "^^^^^^^" in msg
+
+
+def test_error_on_line_two_aligns_to_that_line():
+    """Multi-line script — preview shows the offending line, not line 1."""
+    script = "DS_A := DS_1 + 1;\nDS_B := DS_2[calc x = 5];"
+    with pytest.raises(VTLSyntaxError) as ex:
+        run(script=script, data_structures=_EMPTY_DS, datapoints=_NO_DATA)
+
+    msg = str(ex.value)
+    assert "line 2" in msg
+    assert "DS_B := DS_2[calc x = 5];" in msg
+    # The first line of the script must NOT be quoted as the preview
+    assert "    DS_A := DS_1 + 1;" not in msg
+
+
+def test_tab_indented_script_keeps_caret_aligned():
+    """Tabs in the source line are expanded so the caret aligns to the offending token."""
+    script = "\t\tDS_A := DS_1[calc x = 1];"
+    with pytest.raises(VTLSyntaxError) as ex:
+        run(script=script, data_structures=_EMPTY_DS, datapoints=_NO_DATA)
+
+    msg = str(ex.value)
+    # Tabs should be expanded — the rendered line must not contain a raw \t
+    assert "\t" not in msg
+    # Locate the caret line; it must be a stretch of spaces followed by at least one ^.
+    caret_line = msg.splitlines()[-1]
+    assert caret_line.lstrip(" ") == "^"
+    # And the character directly above the caret must be the `=`.
+    preview_line = msg.splitlines()[-2]
+    caret_col = len(caret_line) - len(caret_line.lstrip(" "))
+    assert preview_line[caret_col] == "="
+
+
+def test_valid_script_still_parses():
+    """Regression guard — a well-formed script does not raise VTLSyntaxError."""
+    data_structures = {
+        "datasets": [
+            {
+                "name": "DS_1",
+                "DataStructure": [
+                    {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+                    {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+                ],
+            }
+        ]
+    }
+    datapoints = {"DS_1": pd.DataFrame({"Id_1": [1, 2, 3], "Me_1": [10.0, 20.0, 30.0]})}
+
+    result = run(
+        script="DS_A <- DS_1 * 2;",
+        data_structures=data_structures,
+        datapoints=datapoints,
+    )
+    assert "DS_A" in result


### PR DESCRIPTION
## Summary

- Extend the `CollectingErrorListener` in the C++ binding to also capture `source_line` and `underline_length` from the offending token's start/stop indices.
- Expand tabs to 4 spaces and remap the column so the caret stays aligned with the offending text.
- Drop the `0-1-4-1` error-code entry — parser errors are free-form and location-stamped; without a code, `str(exc)` is a plain string instead of the tuple `("message", "0-1-4-1")`.
- Rewrite `VTLSyntaxError`: keyword-only constructor, builds the message inline (with the preview block when `source_line` is present).

Before:
```
VTLSyntaxError: ('VTL syntax error at line 1, column 26: ... ', '0-1-4-1')
```
After:
```
VTL syntax error at line 1, column 26: mismatched input '=' expecting ':='
    DS_A <- DS_1[calc test_2 = 42];
                             ^
```

Multi-character offending tokens (e.g. an identifier) get a `^^^...` underline matching the token's length.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest tests/API` — 208, +5 new in `test_syntax_errors.py`)
- [ ] Documentation updated (if applicable) — N/A.

## Impact / Risk

- Public API: `VTLSyntaxError` constructor signature changed (keyword-only `line`/`column`/`detail`/`source_line`/`underline_length`; no longer takes an error code as first positional arg). Callers within vtlengine are updated; external callers constructing `VTLSyntaxError` directly would need to update, but external construction of this class is not expected (it's raised by the engine).
- `str(VTLSyntaxError(...))` returns the formatted message string instead of a `("message", "0-1-4-1")` tuple. Callers comparing against the tuple would break; comparing against the message string still works.
- C++ binding: rebuild required (wheel build picks this up automatically).
- The `0-1-4-1` entry is removed from `centralised_messages`; it was introduced in the same PR series (#725) and never had external consumers.

## Notes

Follows up on #725. Tests cover: single-char caret, multi-char underline, errors on line ≥ 2, tab-indented sources, and a regression guard for valid scripts.

Fixes #726