### PR TITLE
Fix #732: Bump pytest to 9.0.3 and its plugins

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1643,21 +1643,21 @@ xml = ["lxml (>=5.2)", "sdmxschemas (>=1.0.0)", "xmltodict (>=0.13)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -2327,4 +2327,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "025c2d4688b85cb61e50b9aab929ae3f8c7f2149a56116c5a12cb9a90465b6a8"
+content-hash = "7d03b353eb577c2067a4b7851bae8c5daf0313019af8fb35a13eb86e51d4cb24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,9 @@ python = ">=3.10,<4.0"
 # Dependency groups follow PEP 735 (https://peps.python.org/pep-0735/).
 [dependency-groups]
 dev = [
-    "pytest>=8.4,<9.0",
-    "pytest-cov>=7.0.0,<8.0",
-    "coverage>=7.0,!=7.13.0,<8.0",
+    "pytest>=9.0.3,<10.0",
+    "pytest-cov>=7.1.0,<8.0",
+    "coverage>=7.14.0,<8.0",
     "pytest-xdist>=3.8.0,<4.0",
     "mypy>=1.18,<2.0",
     "pyarrow-stubs>=14.0,<25.0",


### PR DESCRIPTION
## Summary

Bumps `pytest` from `>=8.4,<9.0` to `>=9.0.3,<10.0`, and refreshes its directly related plugins (`pytest-cov`, `coverage`). Pytest 9.0 is a major release; isolating the bump keeps it reviewable on its own.

Concrete changes in `pyproject.toml` (`[dependency-groups] dev`):

- `pytest`: `>=8.4,<9.0` → `>=9.0.3,<10.0`
- `pytest-cov`: `>=7.0.0,<8.0` → `>=7.1.0,<8.0`
- `coverage`: `>=7.0,!=7.13.0,<8.0` → `>=7.14.0,<8.0` (drop the `!=7.13.0` exclusion; 7.14+ supersedes the broken release)
- `pytest-xdist`: unchanged (already at latest `3.8.0`)

`poetry.lock` regenerated; effective resolved version change is `pytest 8.4.2 → 9.0.3` (the other plugin versions were already at the new minimums).

Fixes #732.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest` — 4923 passed, 27 skipped locally)
- [ ] Documentation updated (if applicable) — N/A

## Impact / Risk

- **Breaking changes (API/behavior):** none for `vtlengine` users. Pytest 9.0 is a dev-only dependency.
- **Test-suite migration risk:** Low. A pre-scan of `tests/` and `tests/Helper.py` confirmed no use of pytest 9.0–removed APIs (`pytest.warns(None)`, `pytest.raises(None)`, `yield_fixture`, `tmpdir`, `testdir`, `pytest.config`, etc.); all CLI flags in CI workflows remain valid in 9.0.
- **SDMX/data compatibility:** N/A.
- **Release notes:** worth mentioning the pytest major bump for contributors; no user-facing change.

## Notes

Out of scope (intentionally, per maintainer direction on #732):

- Other dev-group entries (`mypy`, `ruff`, `pyarrow-stubs`, `pandas-stubs`, `types-jsonschema`) — to be handled in separate issues/PRs.
- Runtime dependencies under `[project] dependencies`.

Pytest 9.0 changelog: <https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2026-01-09>.