### PR TITLE
QA #687: Check all reference projects execution with duckdb

### DIFF
--- a/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
+++ b/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
@@ -474,7 +474,9 @@ class SQLTranspiler(StructureVisitor, ASTTemplate):
             return self._resolve_udo_param(name, udo_val)
 
         if name in self.scalars:
-            return self._scalar_literal(name)
+            if name in self.input_scalars:
+                return self._scalar_literal(name)
+            return f"(SELECT value FROM {quote_name(name)})"
 
         clause_match = self._resolve_clause_component(name)
         if clause_match is not None:
@@ -1251,25 +1253,53 @@ FROM (
                 cols.append(shifted if comp.name == time_id else col)
             return SQLBuilder().select(*cols).from_table(src).build()
         else:
-            other_ids = [quote_name(c.name) for c in ds.get_identifiers() if c.name != time_id]
-            partition = f"PARTITION BY {', '.join(other_ids)}" if other_ids else ""
-
             cols = []
             for comp in ds.components.values():
                 col = quote_name(comp.name)
                 if comp.name == time_id:
-                    cols.append(f"vtl_dateadd({col}, {shift_sql}, freq.period_ind) AS {col}")
+                    shifted_expr = (
+                        f"CASE WHEN freq.period_ind IN ('M','Q','S','A') "
+                        f"AND CAST({col} AS DATE) = LAST_DAY(CAST({col} AS DATE)) "
+                        f"THEN LAST_DAY(CAST("
+                        f"vtl_dateadd({col}, {shift_sql}, freq.period_ind) AS DATE)) "
+                        f"ELSE vtl_dateadd({col}, {shift_sql}, freq.period_ind) END"
+                    )
+                    cols.append(f"{shifted_expr} AS {col}")
                 else:
                     cols.append(col)
 
-            freq_sql = self._build_date_frequency_subquery(
-                src, time_col, partition, as_period_indicator=True
-            )
+            freq_sql = self._build_timeshift_date_frequency_subquery(src, time_col)
 
             return f"""SELECT {", ".join(cols)}
 FROM {src}, (
     {freq_sql}
 ) AS freq"""
+
+    @staticmethod
+    def _build_timeshift_date_frequency_subquery(src: str, time_col: str) -> str:
+        """Calendar-aware frequency inference for timeshift on Date."""
+        return f"""
+SELECT vtl_date_timeshift_period_ind(
+    COUNT(*),
+    BOOL_OR(NOT clean_month),
+    BOOL_AND(diff_days % 7 = 0),
+    BOOL_AND(clean_month AND diff_months % 12 = 0),
+    BOOL_AND(clean_month AND diff_months % 6 = 0),
+    BOOL_AND(clean_month AND diff_months % 3 = 0)
+) AS period_ind
+FROM (
+    SELECT
+        DATE_DIFF('day', d_prev, d_next) AS diff_days,
+        DATE_DIFF('month', d_prev, d_next) AS diff_months,
+        vtl_date_gap_clean_month(d_prev, d_next) AS clean_month
+    FROM (
+        SELECT LAG({time_col}) OVER (ORDER BY {time_col}) AS d_prev,
+               {time_col} AS d_next
+        FROM {src}
+        WHERE {time_col} IS NOT NULL
+    )
+    WHERE d_prev IS NOT NULL AND d_prev <> d_next
+)""".strip()
 
     def visit_ParamOp_dateadd(self, node: AST.ParamOp) -> str:
         """Visit DATEADD operation: dateadd(op, shiftNumber, periodInd)."""

--- a/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
+++ b/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
@@ -1006,39 +1006,6 @@ class SQLTranspiler(StructureVisitor, ASTTemplate):
         order_by = ", ".join(g_cols)
         return time_col, other_id_cols, measure_cols, join_on, final_select, order_by
 
-    def _build_date_frequency_subquery(
-        self, src: str, time_col: str, partition: str, *, as_period_indicator: bool = False
-    ) -> str:
-        """Build SQL that infers date frequency (or its period indicator) from date diffs."""
-        freq_case = self._build_date_frequency_case(as_period_indicator=as_period_indicator)
-        alias = "period_ind" if as_period_indicator else "step"
-        return f"""
-SELECT {freq_case} AS {alias}
-FROM (
-    SELECT ABS(DATE_DIFF('day',
-        LAG({time_col}) OVER ({partition} ORDER BY {time_col}),
-        {time_col})) AS diff_days
-    FROM {src}
-) WHERE diff_days IS NOT NULL AND diff_days > 0""".strip()
-
-    @staticmethod
-    def _build_date_frequency_case(as_period_indicator: bool) -> str:
-        """Return a CASE expression for inferred date frequency output."""
-        periods = {
-            7: "'D'" if as_period_indicator else "INTERVAL 1 DAY",
-            28: "'W'" if as_period_indicator else "INTERVAL 7 DAY",
-            90: "'M'" if as_period_indicator else "INTERVAL 1 MONTH",
-            181: "'Q'" if as_period_indicator else "INTERVAL 3 MONTH",
-            365: "'S'" if as_period_indicator else "INTERVAL 6 MONTH",
-            "'Inf'::DOUBLE": "'A'" if as_period_indicator else "INTERVAL 1 YEAR",
-        }
-
-        cases = "\n".join(
-            f"WHEN MIN(diff_days) < {value} THEN {period}" for value, period in periods.items()
-        )
-
-        return f"CASE\n{cases}\nEND".strip()
-
     # Shared SQL fragment for the RECURSIVE step that increments a vtl_time_period.
     _TP_NEXT_PERIOD = (
         "CASE"
@@ -1152,13 +1119,16 @@ FROM (
         time_col, other_id_cols, _, join_on, final_select, order_by = self._build_time_grid_parts(
             ds, time_id
         )
-        partition = "PARTITION BY {}".format(", ".join(other_id_cols)) if other_id_cols else ""
         per_group = fill_mode == "single" and bool(other_id_cols)
         freq_step = "(SELECT step FROM freq)"
 
         cte = CTEBuilder()
         cte.cte("source", f"SELECT * FROM {src}")
-        cte.cte("freq", self._build_date_frequency_subquery("source", time_col, partition))
+        freq_inner = self._build_timeshift_date_frequency_subquery("source", time_col)
+        cte.cte(
+            "freq",
+            f"SELECT vtl_period_ind_to_interval(period_ind) AS step FROM ({freq_inner})",
+        )
 
         if per_group:
             oid_csv = ", ".join(other_id_cols)

--- a/src/vtlengine/duckdb_transpiler/sql/time_operators.sql
+++ b/src/vtlengine/duckdb_transpiler/sql/time_operators.sql
@@ -275,6 +275,20 @@ CREATE OR REPLACE MACRO vtl_date_timeshift_period_ind(
     END
 );
 
+-- Map a period indicator to the INTERVAL step expected by generate_series and
+-- friends. Kept colocated with the inference helpers so the period-indicator
+-- vocabulary lives in a single place.
+CREATE OR REPLACE MACRO vtl_period_ind_to_interval(period_ind) AS (
+    CASE period_ind
+        WHEN 'D' THEN INTERVAL 1 DAY
+        WHEN 'W' THEN INTERVAL 7 DAY
+        WHEN 'M' THEN INTERVAL 1 MONTH
+        WHEN 'Q' THEN INTERVAL 3 MONTH
+        WHEN 'S' THEN INTERVAL 6 MONTH
+        WHEN 'A' THEN INTERVAL 1 YEAR
+    END
+);
+
 
 -- ============================================================================
 -- OPERATOR: timeshift (TimePeriod shift by N periods)

--- a/src/vtlengine/duckdb_transpiler/sql/time_operators.sql
+++ b/src/vtlengine/duckdb_transpiler/sql/time_operators.sql
@@ -240,6 +240,43 @@ CREATE OR REPLACE MACRO vtl_time_agg_tp(p vtl_time_period, target VARCHAR) AS (
 
 
 -- ============================================================================
+-- Calendar-aware helpers frequency inference for Date timeshift
+-- ============================================================================
+
+CREATE OR REPLACE MACRO vtl_date_gap_clean_month(d_prev, d_next) AS (
+    DATE_DIFF('month', d_prev, d_next) > 0
+    AND (
+        CAST(d_prev + to_months(CAST(DATE_DIFF('month', d_prev, d_next) AS INTEGER)) AS DATE)
+            = CAST(d_next AS DATE)
+        OR (
+            CAST(d_prev AS DATE) = LAST_DAY(CAST(d_prev AS DATE))
+            AND CAST(d_next AS DATE) = LAST_DAY(CAST(d_next AS DATE))
+        )
+    )
+);
+
+
+CREATE OR REPLACE MACRO vtl_date_timeshift_period_ind(
+    n,
+    has_dirty_gap,
+    all_days_weekly,
+    all_months_annual,
+    all_months_semester,
+    all_months_quarter
+) AS (
+    CASE
+        WHEN n = 0 THEN 'A'
+        WHEN has_dirty_gap THEN
+            CASE WHEN all_days_weekly THEN 'W' ELSE 'D' END
+        WHEN all_months_annual THEN 'A'
+        WHEN all_months_semester THEN 'S'
+        WHEN all_months_quarter THEN 'Q'
+        ELSE 'M'
+    END
+);
+
+
+-- ============================================================================
 -- OPERATOR: timeshift (TimePeriod shift by N periods)
 -- ============================================================================
 

--- a/src/vtlengine/duckdb_transpiler/sql/time_operators.sql
+++ b/src/vtlengine/duckdb_transpiler/sql/time_operators.sql
@@ -275,9 +275,6 @@ CREATE OR REPLACE MACRO vtl_date_timeshift_period_ind(
     END
 );
 
--- Map a period indicator to the INTERVAL step expected by generate_series and
--- friends. Kept colocated with the inference helpers so the period-indicator
--- vocabulary lives in a single place.
 CREATE OR REPLACE MACRO vtl_period_ind_to_interval(period_ind) AS (
     CASE period_ind
         WHEN 'D' THEN INTERVAL 1 DAY

--- a/tests/Bugs/test_bugs.py
+++ b/tests/Bugs/test_bugs.py
@@ -1052,6 +1052,36 @@ class TimeBugs(BugHelper):
 
         self.BaseTest(code=code, number_inputs=number_inputs, references_names=references_names)
 
+    def test_duckdb_derived_scalar_chain(self):
+        """
+        Status: OK
+        Description: DuckDB transpiler inlined scalar references as their
+            transpile-time value. Derived (output-only) scalars have no value
+            at transpile time, so chained scalar arithmetic such as
+            ``b := a + 1; c := b + 1;`` produced ``NULL + 1 = NULL`` and the
+            chain collapsed to NULL.
+        Goal: pandas and DuckDB return the same scalar values across a chain
+            that mixes input scalars, derived scalars and persistent assigns.
+        """
+        script = """
+        a := sc1 + 1;
+        b := a + 1;
+        c <- b;
+        """
+        scalar_values = {"sc1": 5}
+        for engine in (False, True):
+            result = run(
+                script=script,
+                data_structures={"datasets": [], "scalars": [{"name": "sc1", "type": "Integer"}]},
+                datapoints={},
+                scalar_values=scalar_values,
+                return_only_persistent=False,
+                use_duckdb=engine,
+            )
+            assert result["a"].value == 6, f"engine={engine}"
+            assert result["b"].value == 7, f"engine={engine}"
+            assert result["c"].value == 7, f"engine={engine}"
+
 
 class SetBugs(BugHelper):
     """ """


### PR DESCRIPTION
## Summary

- Fixed DuckDB `Timeshift` over a `Date` identifier inferred cadence with a LAG partitioned by other identifiers, so sparse partitions collapsed to `NULL`.
- Fixed derived scalars from other scalars in DuckDB set as `NULL`.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)