### PR TITLE
Checkout the released tag in release.yml and docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.client_payload.tag_name || github.ref }}
           fetch-depth: 0  # Fetch all history for all tags and branches
       - name: Setup Pages
         id: pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.client_payload.tag_name || github.ref }}
 
       - name: Build wheels
         uses: pypa/cibuildwheel@d16cc544083d96996f923fc4b318fee3cb14b34e # v3.4.1


### PR DESCRIPTION
## Summary

When `create-release.yml` triggers `release.yml` and `docs.yml` via `repository_dispatch`, `github.ref` resolves to the workflow's default branch (`main`) rather than the released tag. The publish/docs jobs end up building against `main`'s code instead of the released commit — for a 1.6.X release that means main's 1.8.0 source is built and tagged as the 1.6.X release.

Set `actions/checkout`'s `ref` to `github.event.client_payload.tag_name` when present, falling back to `github.ref` so `release: published`, `workflow_dispatch`, and `pull_request` triggers retain their existing behavior.

## Checklist

- [x] Code quality checks pass (workflow YAML only — no Python touched)
- [ ] Tests pass — N/A
- [ ] Documentation updated — N/A

## Impact / Risk

- Breaking changes? No — falls through to `github.ref` for all triggers other than `repository_dispatch`, matching today's default-checkout behavior.
- Data/SDMX compatibility concerns? None.
- Notes for release/changelog? Internal CI fix; not user-facing.

## Notes

Surfaced while testing a 1.6.X release; the `release-published` dispatch from `create-release.yml` was running main's `release.yml` against main's tip. With this patch, both `release.yml` and `docs.yml` build the actual tag.