### PR TITLE
Dispatch release.yml and docs.yml from the released tag

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   issues: read
   pull-requests: read
@@ -325,11 +326,16 @@ jobs:
               core.info(`Deleted ${preReleases.length} pre-release(s)`);
             }
 
-            // 13. Trigger downstream workflows via repository_dispatch
-            await github.rest.repos.createDispatchEvent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event_type: 'release-published',
-              client_payload: { tag_name: tagName },
-            });
-            core.info('Dispatched release-published event');
+            // 13. Trigger downstream workflows from the released tag's commit.
+            // createWorkflowDispatch (rather than createDispatchEvent) means each
+            // workflow runs the file at the tag's ref — so release branches can
+            // carry their own publish/docs recipe alongside main's.
+            for (const workflow of ['release.yml', 'docs.yml']) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflow,
+                ref: tagName,
+              });
+              core.info(`Dispatched ${workflow} at ref ${tagName}`);
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
     types: [ published ]
   repository_dispatch:
     types: [ release-published ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -45,7 +46,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: [build-wheels]
-    if: github.event_name == 'release' || github.event_name == 'repository_dispatch'
+    if: github.event_name == 'release' || github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## Summary

Replace `create-release.yml`'s `createDispatchEvent` (a `repository_dispatch`, which always runs the default branch's workflow file) with a pair of `createWorkflowDispatch` calls keyed to the just-created tag.

Each downstream workflow now runs the file at the **tag's commit**, so a release branch like `1.6.X` can carry its own publish/docs recipe (poetry build, OIDC trusted publishing, etc.) without having to merge that recipe into main alongside the C++/cibuildwheel flow.

## Changes

- **`release.yml`** — add `workflow_dispatch` trigger; include it in the publish job's event guard.
- **`create-release.yml`** — swap step 13 to dispatch `release.yml` and `docs.yml` individually with `ref: tagName`; add `actions: write` to permissions (required by `createWorkflowDispatch`).
- **`docs.yml`** — no change. Already has `workflow_dispatch` and gates the build/deploy job on it.

The `repository_dispatch` trigger on `release.yml` is left in place for any external callers that may rely on it.

## Checklist

- [x] Code quality checks pass (workflow YAML only)
- [ ] Tests pass — N/A
- [ ] Documentation updated — N/A

## Impact / Risk

- Breaking changes? Only behavioral: future release runs dispatch the tag's workflow files instead of the default branch's. For releases made from main this is a no-op (same code at tag and at main tip when the release lands). For non-main release branches, this is the whole point of the change.
- Permissions: adds `actions: write` to `create-release.yml`. Scope is limited to triggering/cancelling/deleting workflow runs from a manually-invoked workflow.
- Data/SDMX compatibility concerns? None.
- Notes for release/changelog? Internal CI improvement; not user-facing.

## Notes

- Pairs with #737, which made the checkout step in `release.yml`/`docs.yml` use the released tag. With that PR alone, the workflow file was still read from main's tip; this PR closes the loop.
- A release branch that wants to use this needs `workflow_dispatch:` on its own `release.yml` (`docs.yml` is already wired). The `1.6.X` branch will get that as part of the eventual back-port of these workflow fixes.