### PR TITLE
Bump version 1.6.10 with branch-aware release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Create release with notes
         uses: actions/github-script@v8
@@ -31,10 +33,22 @@ jobs:
             const version = versionMatch[1];
             const tagName = `v${version}`;
             core.info(`Version: ${version}, Tag: ${tagName}`);
+            core.info(`Target branch: ${process.env.GITHUB_REF_NAME}`);
 
             // 2. Determine if pre-release
             const isPrerelease = /rc|alpha|beta|dev/.test(version);
             core.info(`Pre-release: ${isPrerelease}`);
+
+            // Tags reachable from this commit — scopes previous-release lookup and
+            // pre-release cleanup to the current branch's lineage.
+            const { execSync } = require('child_process');
+            const reachableTags = new Set(
+              execSync('git tag --merged HEAD', { encoding: 'utf8' })
+                .split('\n')
+                .map(t => t.trim())
+                .filter(Boolean)
+            );
+            core.info(`Reachable tags: ${[...reachableTags].join(', ') || 'none'}`);
 
             // 3. Check tag does not already exist
             try {
@@ -59,9 +73,9 @@ jobs:
             });
             let previousRelease;
             if (isPrerelease) {
-              previousRelease = releases.data[0];
+              previousRelease = releases.data.find(r => reachableTags.has(r.tag_name));
             } else {
-              previousRelease = releases.data.find(r => !r.prerelease);
+              previousRelease = releases.data.find(r => !r.prerelease && reachableTags.has(r.tag_name));
             }
             const previousTag = previousRelease ? previousRelease.tag_name : null;
             core.info(`Previous release: ${previousTag || 'none'}`);
@@ -72,7 +86,7 @@ jobs:
               const comparison = await github.rest.repos.compareCommitsWithBasehead({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                basehead: `${previousTag}...HEAD`,
+                basehead: `${previousTag}...${process.env.GITHUB_SHA}`,
               });
               commits = comparison.data.commits;
             } else {
@@ -100,6 +114,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 tag_name: tagName,
+                target_commitish: process.env.GITHUB_REF_NAME,
                 name: tagName,
                 body: `**Full Changelog**: https://github.com/${context.repo.owner}/${context.repo.repo}/compare/${previousTag}...${tagName}`,
                 prerelease: isPrerelease,
@@ -294,6 +309,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: tagName,
+              target_commitish: process.env.GITHUB_REF_NAME,
               name: tagName,
               body: body,
               prerelease: isPrerelease,
@@ -303,7 +319,7 @@ jobs:
 
             // 12. Delete pre-releases when publishing a stable release
             if (!isPrerelease) {
-              const preReleases = releases.data.filter(r => r.prerelease);
+              const preReleases = releases.data.filter(r => r.prerelease && reachableTags.has(r.tag_name));
               for (const pr of preReleases) {
                 core.info(`Deleting pre-release: ${pr.tag_name}`);
                 await github.rest.repos.deleteRelease({

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   issues: read
   pull-requests: read
@@ -108,63 +109,54 @@ jobs:
             }
             core.info(`Found ${prNumbers.size} PRs: ${[...prNumbers].join(', ')}`);
 
-            if (prNumbers.size === 0) {
-              core.info('No PRs found, creating release with empty notes');
-              await github.rest.repos.createRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag_name: tagName,
-                target_commitish: process.env.GITHUB_REF_NAME,
-                name: tagName,
-                body: `**Full Changelog**: https://github.com/${context.repo.owner}/${context.repo.repo}/compare/${previousTag}...${tagName}`,
-                prerelease: isPrerelease,
-              });
-              return;
-            }
-
-            // 7. Query PR details with linked issues and issue types via GraphQL
-            const prAliases = [...prNumbers].map((n, i) => `
-              pr${i}: pullRequest(number: ${n}) {
-                number
-                title
-                url
-                author { login }
-                labels(first: 10) { nodes { name } }
-                closingIssuesReferences(first: 10, userLinkedOnly: false) {
-                  nodes {
-                    number
-                    issueType { name }
+            // 7. Query PR details with linked issues and issue types via GraphQL.
+            // Skipped when there are no PRs so the empty case flows naturally
+            // through createRelease + cleanup + dispatch with just a changelog link.
+            let prs = [];
+            if (prNumbers.size > 0) {
+              const prAliases = [...prNumbers].map((n, i) => `
+                pr${i}: pullRequest(number: ${n}) {
+                  number
+                  title
+                  url
+                  author { login }
+                  labels(first: 10) { nodes { name } }
+                  closingIssuesReferences(first: 10, userLinkedOnly: false) {
+                    nodes {
+                      number
+                      issueType { name }
+                    }
                   }
                 }
-              }
-            `).join('');
+              `).join('');
 
-            const query = `
-              query {
-                repository(owner: "${context.repo.owner}", name: "${context.repo.repo}") {
-                  ${prAliases}
+              const query = `
+                query {
+                  repository(owner: "${context.repo.owner}", name: "${context.repo.repo}") {
+                    ${prAliases}
+                  }
+                }
+              `;
+
+              // Some numbers extracted from commit messages may be issues, not PRs.
+              // The GraphQL query returns partial data with errors for non-PR numbers,
+              // so we catch the error and use the partial data.
+              let graphqlResult;
+              try {
+                graphqlResult = await github.graphql(query, {
+                  headers: { 'GraphQL-Features': 'issue_types' },
+                });
+              } catch (e) {
+                if (e.data?.repository) {
+                  graphqlResult = { repository: e.data.repository };
+                  core.info(`GraphQL partial errors (non-PR numbers skipped): ${e.errors?.map(err => err.message).join(', ')}`);
+                } else {
+                  throw e;
                 }
               }
-            `;
 
-            // Some numbers extracted from commit messages may be issues, not PRs.
-            // The GraphQL query returns partial data with errors for non-PR numbers,
-            // so we catch the error and use the partial data.
-            let graphqlResult;
-            try {
-              graphqlResult = await github.graphql(query, {
-                headers: { 'GraphQL-Features': 'issue_types' },
-              });
-            } catch (e) {
-              if (e.data?.repository) {
-                graphqlResult = { repository: e.data.repository };
-                core.info(`GraphQL partial errors (non-PR numbers skipped): ${e.errors?.map(err => err.message).join(', ')}`);
-              } else {
-                throw e;
-              }
+              prs = Object.values(graphqlResult.repository).filter(Boolean);
             }
-
-            const prs = Object.values(graphqlResult.repository).filter(Boolean);
 
             // 7b. Fallback: for PRs without closingIssuesReferences, parse issue
             // numbers from title (e.g. "Fix #504:") and query their issue types
@@ -341,11 +333,16 @@ jobs:
               core.info(`Deleted ${preReleases.length} pre-release(s)`);
             }
 
-            // 13. Trigger downstream workflows via repository_dispatch
-            await github.rest.repos.createDispatchEvent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event_type: 'release-published',
-              client_payload: { tag_name: tagName },
-            });
-            core.info('Dispatched release-published event');
+            // 13. Trigger downstream workflows from the released tag's commit.
+            // createWorkflowDispatch (rather than createDispatchEvent) means each
+            // workflow runs the file at the tag's ref — so release branches can
+            // carry their own publish/docs recipe alongside main's.
+            for (const workflow of ['release.yml', 'docs.yml']) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflow,
+                ref: tagName,
+              });
+              core.info(`Dispatched ${workflow} at ref ${tagName}`);
+            }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.client_payload.tag_name || github.ref }}
           fetch-depth: 0  # Fetch all history for all tags and branches
       - name: Setup Pages
         id: pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,11 @@ permissions:
 
 jobs:
   release:
+    name: Publish to PyPI
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -27,4 +31,6 @@ jobs:
       - name: Build package
         run: poetry build
       - name: Publish to PyPI
-        run: poetry publish --username=__token__ --password=${{ secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          attestations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
     types: [ published ]
   repository_dispatch:
     types: [ release-published ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.client_payload.tag_name || github.ref }}
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtlengine"
-version = "1.6.10rc1"
+version = "1.6.10rc2"
 description = "Run and Validate VTL Scripts"
 license = "AGPL-3.0"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtlengine"
-version = "1.6.9"
+version = "1.6.10rc1"
 description = "Run and Validate VTL Scripts"
 license = "AGPL-3.0"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtlengine"
-version = "1.6.10rc2"
+version = "1.6.10rc3"
 description = "Run and Validate VTL Scripts"
 license = "AGPL-3.0"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtlengine"
-version = "1.6.10rc3"
+version = "1.6.10"
 description = "Run and Validate VTL Scripts"
 license = "AGPL-3.0"
 readme = "README.md"

--- a/src/vtlengine/__init__.py
+++ b/src/vtlengine/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     "validate_external_routine",
 ]
 
-__version__ = "1.6.9"
+__version__ = "1.6.10rc1"

--- a/src/vtlengine/__init__.py
+++ b/src/vtlengine/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     "validate_external_routine",
 ]
 
-__version__ = "1.6.10rc1"
+__version__ = "1.6.10rc2"

--- a/src/vtlengine/__init__.py
+++ b/src/vtlengine/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     "validate_external_routine",
 ]
 
-__version__ = "1.6.10rc2"
+__version__ = "1.6.10rc3"

--- a/src/vtlengine/__init__.py
+++ b/src/vtlengine/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     "validate_external_routine",
 ]
 
-__version__ = "1.6.10rc3"
+__version__ = "1.6.10"


### PR DESCRIPTION
## Summary

Release 1.6.10 from the `1.6.X` LTS branch, with a refactored release pipeline that lets `1.6.X` carry its own publish/docs recipe rather than depending on `main`'s C++/cibuildwheel flow.

- **`create-release.yml`** — anchors the tag to the selected branch via `target_commitish`, scopes previous-release lookup and pre-release cleanup to commits reachable from the branch's HEAD, uses `GITHUB_SHA` in the compare API (literal `HEAD` was resolving to the default branch), and replaces the `repository_dispatch` fan-out with two `createWorkflowDispatch` calls keyed to the just-created tag. Removes the empty-notes early-return so 0-PR releases still trigger cleanup and dispatch.
- **`release.yml`** — switches publish to OIDC trusted publishing via `pypa/gh-action-pypi-publish` with `environment: pypi`, sets the checkout `ref` to the released tag, and adds a `workflow_dispatch` trigger so the tag-scoped dispatch from `create-release.yml` can invoke it. Keeps the existing poetry build (pure-Python wheel) — the 1.6.X branch does not adopt the C++ parser.
- **`docs.yml`** — sets the checkout `ref` to the released tag so docs build from the tagged commit instead of the default branch's tip.

Mirrors the main-side changes in #737 (checkout the released tag) and #738 (dispatch by tag).

## Checklist

- [x] Code quality checks pass (workflow YAML only — no Python touched)
- [ ] Tests pass — N/A
- [x] Documentation updated — N/A (no user-facing API change)

## Impact / Risk

- Breaking changes? None for users. CI behavior changes:
  - Releases from `1.6.X` now tag against `1.6.X`'s HEAD and not the default branch.
  - Pre-release cleanup is scoped to the branch — pre-releases on other branches are no longer affected when a stable on this branch is published.
  - Release notes enumerate commits actually on this branch.
- Data/SDMX compatibility concerns? None.
- Notes for release/changelog? This is the **1.6.10** release. Test runs (rc1, rc2, rc3 on PyPI) validated the full create-release → dispatch → publish flow end-to-end on this branch; the published wheel was confirmed byte-identical to `src/vtlengine/` at the tag.

## Notes

- Closes the loop with main-side PRs #737 + #738. With those merged on `main`, this branch's `release.yml`/`docs.yml` are the ones that run at the released tag (poetry + OIDC), instead of falling back to `main`'s cibuildwheel pipeline.
- History contains rc2/rc3 testing commits; squash-on-merge will collapse them. The final tree state is what matters.
- After merge, the test-only branch policy entry added to the `pypi` GitHub Environment for `workflow-1.6.X-changes` can be removed.