### PR TITLE
1.6.X: Also clean up the current stable's rcs even when not reachable

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -309,9 +309,18 @@ jobs:
 
             core.info(`Release ${tagName} created successfully`);
 
-            // 12. Delete pre-releases when publishing a stable release
+            // 12. Delete pre-release entries when publishing a stable release.
+            // Tags are intentionally left in place so the rc commits remain
+            // navigable; only the GitHub Release objects are removed.
             if (!isPrerelease) {
-              const preReleases = releases.data.filter(r => r.prerelease && reachableTags.has(r.tag_name));
+              const preReleases = releases.data.filter(r => {
+                if (!r.prerelease) return false;
+                if (reachableTags.has(r.tag_name)) return true;
+                // Catch rcs of this exact stable that aren't reachable —
+                // e.g., after a squash-merge severs the rc commits from the
+                // branch's lineage.
+                return /^(rc|alpha|beta|dev)\d*$/.test(r.tag_name.slice(tagName.length));
+              });
               for (const pr of preReleases) {
                 core.info(`Deleting pre-release: ${pr.tag_name}`);
                 await github.rest.repos.deleteRelease({
@@ -319,16 +328,6 @@ jobs:
                   repo: context.repo.repo,
                   release_id: pr.id,
                 });
-                // Delete the associated tag
-                try {
-                  await github.rest.git.deleteRef({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    ref: `tags/${pr.tag_name}`,
-                  });
-                } catch (e) {
-                  core.warning(`Could not delete tag ${pr.tag_name}: ${e.message}`);
-                }
               }
               core.info(`Deleted ${preReleases.length} pre-release(s)`);
             }

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -309,9 +309,7 @@ jobs:
 
             core.info(`Release ${tagName} created successfully`);
 
-            // 12. Delete pre-release entries when publishing a stable release.
-            // Tags are intentionally left in place so the rc commits remain
-            // navigable; only the GitHub Release objects are removed.
+            // 12. Delete pre-releases when publishing a stable release
             if (!isPrerelease) {
               const preReleases = releases.data.filter(r => {
                 if (!r.prerelease) return false;
@@ -328,6 +326,16 @@ jobs:
                   repo: context.repo.repo,
                   release_id: pr.id,
                 });
+                // Delete the associated tag
+                try {
+                  await github.rest.git.deleteRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: `tags/${pr.tag_name}`,
+                  });
+                } catch (e) {
+                  core.warning(`Could not delete tag ${pr.tag_name}: ${e.message}`);
+                }
               }
               core.info(`Deleted ${preReleases.length} pre-release(s)`);
             }


### PR DESCRIPTION
## Summary

Extend the pre-release cleanup filter so it also catches rcs of the exact stable being published when they aren't reachable from the branch's HEAD — the squash-merge case we hit publishing 1.6.10.

Previously (after #739): `r.prerelease && reachableTags.has(r.tag_name)`.

Now:

```javascript
const preReleases = releases.data.filter(r => {
  if (!r.prerelease) return false;
  if (reachableTags.has(r.tag_name)) return true;
  // Catch rcs of this exact stable that aren't reachable —
  // e.g., after a squash-merge severs the rc commits from the
  // branch's lineage.
  return /^(rc|alpha|beta|dev)\d*$/.test(r.tag_name.slice(tagName.length));
});
```

The existing release-and-tag deletion behavior is unchanged: both the GitHub Release entry and the underlying tag are removed, matching the historical behavior (v1.7.0 cleaned up `v1.7.0rc1/rc2/rc3` releases *and* tags).

## Checklist

- [x] Code quality checks pass (workflow YAML only)
- [ ] Tests pass — N/A
- [ ] Documentation updated — N/A

## Impact / Risk

- Behavior change: pre-releases named `<currentTag>(rc|alpha|beta|dev)<digits>` are now always cleaned up at stable release time, even when not reachable from HEAD. The reachable-tags scoping for *other* pre-releases is preserved (no cross-train cleanup).
- The v1.6.10rc1/rc2/rc3 entries already on the repo will not be cleaned up by this PR — they would only be touched by a *future* stable release that matched the prefix. Manual deletion if needed.

## Notes

This is a follow-up to #739. The same fix should be ported to `main`'s `create-release.yml` when the broader 1.6.X workflow back-port lands there.