### PR TITLE
main: Back-port branch-aware create-release.yml from 1.6.X

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Create release with notes
         uses: actions/github-script@v8
@@ -36,6 +38,18 @@ jobs:
             // 2. Determine if pre-release
             const isPrerelease = /rc|alpha|beta|dev/.test(version);
             core.info(`Pre-release: ${isPrerelease}`);
+
+            // Tags reachable from this commit — scopes pre-release cleanup
+            // to the current branch's lineage so a stable on one release
+            // train doesn't sweep pre-releases on another.
+            const { execSync } = require('child_process');
+            const reachableTags = new Set(
+              execSync('git tag --merged HEAD', { encoding: 'utf8' })
+                .split('\n')
+                .map(t => t.trim())
+                .filter(Boolean)
+            );
+            core.info(`Reachable tags: ${[...reachableTags].join(', ') || 'none'}`);
 
             // 3. Check tag does not already exist
             try {
@@ -304,7 +318,14 @@ jobs:
 
             // 12. Delete pre-releases when publishing a stable release
             if (!isPrerelease) {
-              const preReleases = releases.data.filter(r => r.prerelease);
+              const preReleases = releases.data.filter(r => {
+                if (!r.prerelease) return false;
+                if (reachableTags.has(r.tag_name)) return true;
+                // Catch rcs of this exact stable that aren't reachable —
+                // e.g., after a squash-merge severs the rc commits from the
+                // branch's lineage.
+                return /^(rc|alpha|beta|dev)\d*$/.test(r.tag_name.slice(tagName.length));
+              });
               for (const pr of preReleases) {
                 core.info(`Deleting pre-release: ${pr.tag_name}`);
                 await github.rest.repos.deleteRelease({

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,6 +34,7 @@ jobs:
             const version = versionMatch[1];
             const tagName = `v${version}`;
             core.info(`Version: ${version}, Tag: ${tagName}`);
+            core.info(`Target branch: ${process.env.GITHUB_REF_NAME}`);
 
             // 2. Determine if pre-release
             const isPrerelease = /rc|alpha|beta|dev/.test(version);
@@ -74,9 +75,9 @@ jobs:
             });
             let previousRelease;
             if (isPrerelease) {
-              previousRelease = releases.data[0];
+              previousRelease = releases.data.find(r => reachableTags.has(r.tag_name));
             } else {
-              previousRelease = releases.data.find(r => !r.prerelease);
+              previousRelease = releases.data.find(r => !r.prerelease && reachableTags.has(r.tag_name));
             }
             const previousTag = previousRelease ? previousRelease.tag_name : null;
             core.info(`Previous release: ${previousTag || 'none'}`);
@@ -87,7 +88,7 @@ jobs:
               const comparison = await github.rest.repos.compareCommitsWithBasehead({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                basehead: `${previousTag}...HEAD`,
+                basehead: `${previousTag}...${process.env.GITHUB_SHA}`,
               });
               commits = comparison.data.commits;
             } else {
@@ -109,62 +110,54 @@ jobs:
             }
             core.info(`Found ${prNumbers.size} PRs: ${[...prNumbers].join(', ')}`);
 
-            if (prNumbers.size === 0) {
-              core.info('No PRs found, creating release with empty notes');
-              await github.rest.repos.createRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag_name: tagName,
-                name: tagName,
-                body: `**Full Changelog**: https://github.com/${context.repo.owner}/${context.repo.repo}/compare/${previousTag}...${tagName}`,
-                prerelease: isPrerelease,
-              });
-              return;
-            }
-
-            // 7. Query PR details with linked issues and issue types via GraphQL
-            const prAliases = [...prNumbers].map((n, i) => `
-              pr${i}: pullRequest(number: ${n}) {
-                number
-                title
-                url
-                author { login }
-                labels(first: 10) { nodes { name } }
-                closingIssuesReferences(first: 10, userLinkedOnly: false) {
-                  nodes {
-                    number
-                    issueType { name }
+            // 7. Query PR details with linked issues and issue types via GraphQL.
+            // Skipped when there are no PRs so the empty case flows naturally
+            // through createRelease + cleanup + dispatch with just a changelog link.
+            let prs = [];
+            if (prNumbers.size > 0) {
+              const prAliases = [...prNumbers].map((n, i) => `
+                pr${i}: pullRequest(number: ${n}) {
+                  number
+                  title
+                  url
+                  author { login }
+                  labels(first: 10) { nodes { name } }
+                  closingIssuesReferences(first: 10, userLinkedOnly: false) {
+                    nodes {
+                      number
+                      issueType { name }
+                    }
                   }
                 }
-              }
-            `).join('');
+              `).join('');
 
-            const query = `
-              query {
-                repository(owner: "${context.repo.owner}", name: "${context.repo.repo}") {
-                  ${prAliases}
+              const query = `
+                query {
+                  repository(owner: "${context.repo.owner}", name: "${context.repo.repo}") {
+                    ${prAliases}
+                  }
+                }
+              `;
+
+              // Some numbers extracted from commit messages may be issues, not PRs.
+              // The GraphQL query returns partial data with errors for non-PR numbers,
+              // so we catch the error and use the partial data.
+              let graphqlResult;
+              try {
+                graphqlResult = await github.graphql(query, {
+                  headers: { 'GraphQL-Features': 'issue_types' },
+                });
+              } catch (e) {
+                if (e.data?.repository) {
+                  graphqlResult = { repository: e.data.repository };
+                  core.info(`GraphQL partial errors (non-PR numbers skipped): ${e.errors?.map(err => err.message).join(', ')}`);
+                } else {
+                  throw e;
                 }
               }
-            `;
 
-            // Some numbers extracted from commit messages may be issues, not PRs.
-            // The GraphQL query returns partial data with errors for non-PR numbers,
-            // so we catch the error and use the partial data.
-            let graphqlResult;
-            try {
-              graphqlResult = await github.graphql(query, {
-                headers: { 'GraphQL-Features': 'issue_types' },
-              });
-            } catch (e) {
-              if (e.data?.repository) {
-                graphqlResult = { repository: e.data.repository };
-                core.info(`GraphQL partial errors (non-PR numbers skipped): ${e.errors?.map(err => err.message).join(', ')}`);
-              } else {
-                throw e;
-              }
+              prs = Object.values(graphqlResult.repository).filter(Boolean);
             }
-
-            const prs = Object.values(graphqlResult.repository).filter(Boolean);
 
             // 7b. Fallback: for PRs without closingIssuesReferences, parse issue
             // numbers from title (e.g. "Fix #504:") and query their issue types
@@ -309,6 +302,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: tagName,
+              target_commitish: process.env.GITHUB_REF_NAME,
               name: tagName,
               body: body,
               prerelease: isPrerelease,


### PR DESCRIPTION
## Summary

Back-port the `create-release.yml` improvements from 1.6.X (#739 + #740) to main so future maintenance branches (and main itself) benefit from the same branch-aware behavior.

### Tag anchoring + diagnostics
- `target_commitish: process.env.GITHUB_REF_NAME` on `createRelease` — the tag is anchored to the selected branch instead of defaulting to the repo's default.
- `core.info(\`Target branch: ${process.env.GITHUB_REF_NAME}\`)` in the run output.

### Branch-lineage scoping
- `actions/checkout@v6` with `fetch-depth: 0` so `git tag --merged HEAD` sees the tags.
- `reachableTags = new Set(git tag --merged HEAD)` computed once.
- `previousRelease` lookup is scoped to reachable tags — release notes won't pick up a stable from a different release train.
- Pre-release cleanup filter is scoped to: reachable OR `<tagName>(rc|alpha|beta|dev)<digits>` (the squash-merge safety net).

### Commit enumeration
- `basehead: \`${previousTag}...${process.env.GITHUB_SHA}\`` — the literal `HEAD` in `compareCommitsWithBasehead` resolves to the repo's default branch server-side, not the runner's checkout. `GITHUB_SHA` is the actual commit being tagged.

### Empty-notes path refactor
- The early-return on `prNumbers.size === 0` skipped step 12 (pre-release cleanup) and step 13 (dispatch). Gating the GraphQL block on `prNumbers.size > 0` lets the flow run uniformly. Body for 0-PR releases stays the same: just the "Full Changelog" link.

## Checklist

- [x] Code quality checks pass (workflow YAML only — no Python touched)
- [ ] Tests pass — N/A
- [ ] Documentation updated — N/A

## Impact / Risk

- For releases made from `main`: behavior is effectively unchanged when `main` is the default branch and the only release train (target_commitish resolves to `main`; reachable tags cover everything in `main`'s history).
- For releases made from a maintenance branch (e.g., a future `1.6.X`-style branch): the tag lands on that branch, release notes reflect that branch's lineage, cleanup respects train boundaries.
- The squash-merge safety net in the cleanup filter preserves the historical behavior of also wiping the current stable's rcs (e.g., the v1.7.0 case that deleted v1.7.0rc2/rc3).
- 1.6.X (#739) has been exercised end-to-end with rc1/rc2/rc3 → 1.6.10 on PyPI.

## Notes

This consolidates #741's original scope (just the cleanup filter) with the rest of the back-port. Pairs with #740 (the smaller 1.6.X-side update to the cleanup filter).