### PR TITLE
Fix #744: Resolve docs versions list refs through origin/ fallback

### DIFF
--- a/docs/scripts/build_multiversion.py
+++ b/docs/scripts/build_multiversion.py
@@ -60,6 +60,25 @@ def overlay_current_docs(worktree: Path) -> None:
             shutil.copy2(src, dst)
 
 
+def resolve_worktree_ref(ref: str) -> str:
+    """Return a ref name that ``git worktree add`` can resolve.
+
+    When the CI checkout is a detached HEAD at a tag, branch names like ``main``
+    only exist as remote-tracking refs (``origin/main``); ``git worktree add``
+    does not DWIM a bare branch name to its remote counterpart. Tries the ref
+    as-is first, then falls back to ``origin/<ref>``.
+    """
+    for candidate in (ref, f"origin/{ref}"):
+        result = subprocess.run(  # noqa: S603
+            ["git", "rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}"],  # noqa: S607
+            cwd=REPO_ROOT,
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            return candidate
+    raise SystemExit(f"Cannot resolve git ref {ref!r} (tried {ref!r} and {f'origin/{ref}'!r})")
+
+
 def build_one_version(
     ref: str,
     out_dir: Path,
@@ -67,10 +86,11 @@ def build_one_version(
     latest_stable: Optional[str],
 ) -> None:
     """Check out `ref` into a temp worktree, overlay current docs, and run sphinx-build."""
+    resolved_ref = resolve_worktree_ref(ref)
     with tempfile.TemporaryDirectory(prefix=f"vtlengine-docs-{ref.replace('/', '_')}-") as tmp:
         worktree = Path(tmp) / "wt"
         subprocess.run(  # noqa: S603
-            ["git", "worktree", "add", "--detach", str(worktree), ref],  # noqa: S607
+            ["git", "worktree", "add", "--detach", str(worktree), resolved_ref],  # noqa: S607
             cwd=REPO_ROOT,
             check=True,
         )


### PR DESCRIPTION
## Summary

Fix the regression that caused [`Publish documentation` run #26095062718](https://github.com/Meaningful-Data/vtlengine/actions/runs/26095062718) to fail on `workflow_dispatch` against tag `v1.8.0` with:

```
=== Building main -> _site/main ===
fatal: invalid reference: main
git worktree add --detach /tmp/vtlengine-docs-main-.../wt main → exit 128
```

`docs/scripts/build_multiversion.py` passes bare branch names (e.g. `main`) from `_versions.json` straight to `git worktree add --detach`. When the workflow checks out a tag (post #737/#738), HEAD is detached and `main` only exists as `refs/remotes/origin/main` — `git worktree add` does not DWIM that resolution, so the build aborts on the first iteration. Tag refs were unaffected.

The fix adds `resolve_worktree_ref()` which tries the bare ref first, then falls back to `origin/<ref>`. Tags continue to resolve as-is; branch names get the `origin/` prefix only when no local branch is present.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — unchanged; helper exercised by the docs build itself
- [ ] Documentation updated (if applicable) — N/A

## Impact / Risk

- No API or behavior change for end users.
- Locally-resolvable refs (current behavior for `pull_request closed` runs) take the same path as before — the fallback only kicks in when the bare ref doesn't resolve.
- No changes to `docs.yml`; the intent of #737/#738 (tag-pinned dispatch) is preserved.

## Notes

Reproduced and validated locally against a detached-HEAD clone at `v1.8.0`:

```
git worktree add --detach <wt> main         # fatal: invalid reference: main
git worktree add --detach <wt> origin/main  # success
```

`resolve_worktree_ref()` returns `origin/main` for `main`, `v1.8.0` for `v1.8.0`, and raises a clear `SystemExit` for fully-unresolvable refs.

After this merges, re-running `Publish documentation` via `workflow_dispatch` (from `main` or any branch carrying the fix) should publish `main` plus the latest stable tags as configured by `configure_doc_versions.py`.

Fixes #744
