### PR TITLE
Fix #746: Simple Round/Trunc ASTString generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtlengine"
-version = "1.6.10"
+version = "1.6.11"
 description = "Run and Validate VTL Scripts"
 license = "AGPL-3.0"
 readme = "README.md"

--- a/src/vtlengine/AST/ASTString.py
+++ b/src/vtlengine/AST/ASTString.py
@@ -324,10 +324,10 @@ class ASTString(ASTTemplate):
             return f"{node.op} {self.visit(node.params)}"
         elif node.op in [SUBSTR, INSTR, REPLACE, ROUND, TRUNC, UNION, SETDIFF, SYMDIFF, INTERSECT]:
             params_sep = ", " if len(node.params) > 1 else ""
-            return (
-                f"{node.op}({self.visit(node.children[0])}, "
-                f"{params_sep.join([self.visit(x) for x in node.params])})"
-            )
+            param_values = [self.visit(x) for x in node.params]
+            if not param_values:
+                return f"{node.op}({self.visit(node.children[0])})"
+            return f"{node.op}({self.visit(node.children[0])}, {params_sep.join(param_values)})"
 
         elif node.op in (CHECK_HIERARCHY, HIERARCHY):
             if len(node.children) == 2:

--- a/src/vtlengine/__init__.py
+++ b/src/vtlengine/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     "validate_external_routine",
 ]
 
-__version__ = "1.6.10"
+__version__ = "1.6.11"

--- a/tests/AST/data/vtl/round_with_slash.vtl
+++ b/tests/AST/data/vtl/round_with_slash.vtl
@@ -1,2 +1,4 @@
 round_with_empty <- round(15.56789, _);
+simple_round:= round(16.56789);
 trunc_with_empty <- trunc(15.56789, _);
+simple_trunc:= trunc(16.56789);


### PR DESCRIPTION
## Summary

AstString from no param Round/Trunc no longer returns an empty param.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)
