### PR TITLE
Fix #763: Dataset level ops between datasets with non related ids must fail

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ on:
 
   pull_request:
     types: [ closed ]
-    branches: [ main, 1.6.X ]
+    branches: [ main, 1.9.X, 1.6.X ]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: Testing
 
 on:
   pull_request:
-    branches: ["main", "1.6.X"]
+    branches: ["main", "1.9.X", "1.6.X"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -2,7 +2,7 @@ name: Ubuntu 24.04 Tests
 
 on:
   pull_request:
-    branches: ["main", "1.6.X"]
+    branches: ["main", "1.9.X", "1.6.X"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -2,9 +2,9 @@ name: Version Consistency Check
 
 on:
   push:
-    branches: [ main, 1.6.X ]
+    branches: [ main, 1.9.X, 1.6.X ]
   pull_request:
-    branches: [ main, 1.6.X ]
+    branches: [ main, 1.9.X, 1.6.X ]
 
 permissions:
   contents: read

--- a/src/vtlengine/Exceptions/messages.py
+++ b/src/vtlengine/Exceptions/messages.py
@@ -54,7 +54,7 @@ centralised_messages = {
         "description": "Occurs when the input CSV file does not contain any data.",
     },
     "0-1-1-8": {
-        "message": "The following Identifiers {ids} were not found , review file {file}.",
+        "message": "The following Identifiers {ids} were not found, review file {file}.",
         "description": "Raised when certain expected Identifiers are missing in the input Dataset.",
     },
     "0-1-1-9": {
@@ -940,6 +940,13 @@ centralised_messages = {
         "message": "At op {op}: Cannot perform aggregation inside a Calc.",
         "description": "Occurs when an aggregation operation is attempted inside a "
         "Calc expression.",
+    },
+    "1-2-15": {
+        "message": "At op {op}: incompatible identifier sets between datasets {left_name} {left} "
+        "and {right_name} {right}: the operands must have the same identifiers, or one set must "
+        "be a subset of the other.",
+        "description": "Raised when a binary dataset operator is applied to two datasets whose "
+        "identifier sets are neither equal nor in a subset relationship.",
     },
     # AST Helpers
     "1-3-1-1": {

--- a/src/vtlengine/Operators/Comparison.py
+++ b/src/vtlengine/Operators/Comparison.py
@@ -471,10 +471,17 @@ class ExistIn(Operator.Operator):
         left_identifiers = dataset_1.get_identifiers_names()
         right_identifiers = dataset_2.get_identifiers_names()
 
-        is_subset_right = set(right_identifiers).issubset(left_identifiers)
-        is_subset_left = set(left_identifiers).issubset(right_identifiers)
-        if not (is_subset_left or is_subset_right):
-            raise ValueError("Datasets must have common identifiers")
+        left_ids_set = set(left_identifiers)
+        right_ids_set = set(right_identifiers)
+        if not (left_ids_set.issubset(right_ids_set) or right_ids_set.issubset(left_ids_set)):
+            raise SemanticError(
+                "1-2-15",
+                op=cls.op,
+                left_name=dataset_1.name,
+                left=sorted(left_ids_set),
+                right_name=dataset_2.name,
+                right=sorted(right_ids_set),
+            )
 
         result_components = {comp.name: copy(comp) for comp in dataset_1.get_identifiers()}
         result_dataset = Dataset(name=dataset_name, components=result_components, data=None)

--- a/src/vtlengine/Operators/__init__.py
+++ b/src/vtlengine/Operators/__init__.py
@@ -317,9 +317,19 @@ class Binary(Operator):
         del left_measures_names
         del right_measures_names
 
-        join_keys = list(set(left_identifiers).intersection(right_identifiers))
-        if len(join_keys) == 0:
+        left_ids_set = set(left_identifiers)
+        right_ids_set = set(right_identifiers)
+        if not left_ids_set or not right_ids_set:
             raise SemanticError("1-2-10", op=cls.op)
+        if not (left_ids_set.issubset(right_ids_set) or right_ids_set.issubset(left_ids_set)):
+            raise SemanticError(
+                "1-2-15",
+                op=cls.op,
+                left_name=left_operand.name,
+                left=sorted(left_ids_set),
+                right_name=right_operand.name,
+                right=sorted(right_ids_set),
+            )
 
         # Deleting extra identifiers that we do not need anymore
 

--- a/tests/DataLoad/test_dataload.py
+++ b/tests/DataLoad/test_dataload.py
@@ -289,7 +289,7 @@ class DataLoadTest(DataLoadHelper):
         code = "GL_81-15"
         number_inputs = 1
 
-        message = "The following Identifiers Id_1 were not found , review file GL_81-15-1.csv"
+        message = "The following Identifiers Id_1 were not found, review file GL_81-15-1.csv"
         self.DataLoadExceptionTest(
             code=code, number_inputs=number_inputs, exception_message=message
         )
@@ -305,7 +305,7 @@ class DataLoadTest(DataLoadHelper):
         code = "GL_81-16"
         number_inputs = 1
 
-        message = "The following Identifiers VLD_T were not found , review file GL_81-16-1.csv"
+        message = "The following Identifiers VLD_T were not found, review file GL_81-16-1.csv"
         self.DataLoadExceptionTest(
             code=code, number_inputs=number_inputs, exception_message=message
         )

--- a/tests/Semantic/test_semantic.py
+++ b/tests/Semantic/test_semantic.py
@@ -3037,3 +3037,81 @@ def test_GH_676_4():
     with pytest.raises(SemanticError) as ctx:
         interpreter.visit(ast)
     assert ctx.value.args[1] == "1-2-8"
+
+
+# Binary dataset operators: identifier sets must be equal or one a subset of the other (1-2-15).
+
+_INCOMPATIBLE_IDS_STRUCTURES = {
+    "datasets": [
+        {
+            "name": "DS_1",
+            "DataStructure": [
+                {"name": "Id_1", "type": "String", "role": "Identifier", "nullable": False},
+                {"name": "Id_2", "type": "Number", "role": "Identifier", "nullable": False},
+                {"name": "Id_3", "type": "Number", "role": "Identifier", "nullable": False},
+                {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+            ],
+        },
+        {
+            "name": "DS_2",
+            "DataStructure": [
+                {"name": "Id_1", "type": "String", "role": "Identifier", "nullable": False},
+                {"name": "Id_4", "type": "Number", "role": "Identifier", "nullable": False},
+                {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+            ],
+        },
+        {
+            "name": "DS_DISJOINT",
+            "DataStructure": [
+                {"name": "Id_9", "type": "String", "role": "Identifier", "nullable": False},
+                {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+            ],
+        },
+        {
+            "name": "DS_SUBSET",
+            "DataStructure": [
+                {"name": "Id_1", "type": "String", "role": "Identifier", "nullable": False},
+                {"name": "Id_2", "type": "Number", "role": "Identifier", "nullable": False},
+                {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+            ],
+        },
+    ]
+}
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "DS_r := DS_1 + DS_2;",
+        "DS_r := DS_1 - DS_2;",
+        "DS_r := DS_1 * DS_2;",
+        "DS_r := DS_1 = DS_2;",
+    ],
+)
+def test_binary_incompatible_identifiers_overlap_not_subset(script: str) -> None:
+    """Binary ops fail when identifier sets overlap but neither is a subset of the other."""
+    with pytest.raises(SemanticError) as ctx:
+        semantic_analysis(script=script, data_structures=_INCOMPATIBLE_IDS_STRUCTURES)
+    assert ctx.value.args[1] == "1-2-15"
+
+
+def test_binary_incompatible_identifiers_disjoint() -> None:
+    """Binary op fails when identifier sets are disjoint (still neither subset)."""
+    script = "DS_r := DS_1 + DS_DISJOINT;"
+    with pytest.raises(SemanticError) as ctx:
+        semantic_analysis(script=script, data_structures=_INCOMPATIBLE_IDS_STRUCTURES)
+    assert ctx.value.args[1] == "1-2-15"
+
+
+def test_binary_subset_identifiers_ok() -> None:
+    """Binary op succeeds when one identifier set is a strict subset of the other."""
+    script = "DS_r := DS_1 + DS_SUBSET;"
+    semantic_analysis(script=script, data_structures=_INCOMPATIBLE_IDS_STRUCTURES)
+
+
+def test_exists_in_incompatible_identifiers() -> None:
+    """exists_in fails when identifier sets overlap but neither is a subset of the other."""
+    script = "DS_r := exists_in(DS_1, DS_2);"
+    with pytest.raises(SemanticError) as ctx:
+        semantic_analysis(script=script, data_structures=_INCOMPATIBLE_IDS_STRUCTURES)
+    assert ctx.value.args[1] == "1-2-15"

--- a/tests/Semantic/test_semantic.py
+++ b/tests/Semantic/test_semantic.py
@@ -3083,6 +3083,7 @@ _INCOMPATIBLE_IDS_STRUCTURES = {
     "script",
     [
         "DS_r := DS_1 + DS_2;",
+        "DS_r := DS_2 + DS_1;",
         "DS_r := DS_1 - DS_2;",
         "DS_r := DS_1 * DS_2;",
         "DS_r := DS_1 = DS_2;",


### PR DESCRIPTION
## Summary

Non subset dataset ops now raise Semantic error

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)
