### PR TITLE
ci: bump Ubuntu 24.04 pip pins; add 1.9.X to workflow triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ on:
 
   pull_request:
     types: [ closed ]
-    branches: [ main, 1.6.X ]
+    branches: [ main, 1.6.X, 1.9.X ]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: Testing
 
 on:
   pull_request:
-    branches: ["main", "1.6.X"]
+    branches: ["main", "1.6.X", "1.9.X"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -2,7 +2,7 @@ name: Ubuntu 24.04 Tests
 
 on:
   pull_request:
-    branches: ["main", "1.6.X"]
+    branches: ["main", "1.6.X", "1.9.X"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -57,12 +57,12 @@ jobs:
       - name: Install pip-only dependencies
         run: |
           pip install --no-dependencies --break-system-packages \
-            pyarrow==14.0.2 \
+            pyarrow==24.0.0 \
             sdmxschemas==1.0.0 \
             parsy==2.2 \
-            msgspec==0.19.0 \
-            duckdb==1.4.1 \
-            pysdmx==1.9.0
+            msgspec==0.21.1 \
+            duckdb==1.4.4 \
+            pysdmx==1.15.1
 
       - name: Download ANTLR4 C++ runtime source
         if: steps.cpp-cache.outputs.cache-hit != 'true' && steps.antlr4-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -2,9 +2,9 @@ name: Version Consistency Check
 
 on:
   push:
-    branches: [ main, 1.6.X ]
+    branches: [ main, 1.6.X, 1.9.X ]
   pull_request:
-    branches: [ main, 1.6.X ]
+    branches: [ main, 1.6.X, 1.9.X ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Sync the Ubuntu 24.04 test workflow's hardcoded `pip --no-dependencies` pins to the versions already locked in `poetry.lock`, and register the active `1.9.X` maintenance branch as a CI trigger across every workflow that already lists `1.6.X`.

`ubuntu_test_24_04.yml` installs a handful of dependencies via `pip install --no-dependencies` (the rest come from apt), so those pins are maintained by hand and had drifted behind `pyproject.toml`/`poetry.lock` — e.g. it installed `pysdmx==1.9.0` even though the project now requires `>=1.15.1`. This realigns them:

| Package | Before | After |
| --- | --- | --- |
| pyarrow | 14.0.2 | 24.0.0 |
| msgspec | 0.19.0 | 0.21.1 |
| duckdb | 1.4.1 | 1.4.4 |
| pysdmx | 1.9.0 | 1.15.1 |
| sdmxschemas | 1.0.0 | 1.0.0 (unchanged) |
| parsy | 2.2 | 2.2 (unchanged) |

It also adds `1.9.X` to the branch filters in `ubuntu_test_24_04.yml`, `testing.yml`, `version.yml`, and `docs.yml`, matching how `1.6.X` is already configured, so PRs targeting the active `1.9.X` branch get the full CI suite (Ubuntu tests, main test matrix, version-consistency check, docs build).

## Checklist

- [ ] Code quality checks pass (`ruff format`, `ruff check`, `mypy`) — N/A, no Python changed
- [ ] Tests pass (`pytest`) — N/A, no Python changed
- [ ] Documentation updated (if applicable) — N/A
- [x] All four workflow YAML files validated (parse cleanly); new pip pins verified against `poetry.lock`

## Impact / Risk

- **Breaking changes?** No — CI configuration only.
- **Data/SDMX compatibility concerns?** None. The new pip pins match the versions already resolved in `poetry.lock`/`pyproject.toml`.
- **Notes for release/changelog?** CI/workflows maintenance.

## Notes

- The dependency bumps in `pyproject.toml`/`poetry.lock` are already on `main`; this PR only syncs the Ubuntu workflow's manual pip pins (which `pip --no-dependencies` does not read from the lockfile) and broadens the branch triggers.
- The `1.9.X` trigger was added to **all four** workflows that list `1.6.X` (maintainer decision), not just the Ubuntu workflow, so the maintenance branch receives the same CI coverage as `main` and `1.6.X`.

Fixes #787
