### PR TITLE
ci: sync Ubuntu 24.04 pip pins to poetry.lock on 1.9.X

### DIFF
--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -57,12 +57,12 @@ jobs:
       - name: Install pip-only dependencies
         run: |
           pip install --no-dependencies --break-system-packages \
-            pyarrow==14.0.2 \
+            pyarrow==24.0.0 \
             sdmxschemas==1.0.0 \
             parsy==2.2 \
-            msgspec==0.19.0 \
-            duckdb==1.4.1 \
-            pysdmx==1.9.0
+            msgspec==0.21.1 \
+            duckdb==1.4.4 \
+            pysdmx==1.15.1
 
       - name: Download ANTLR4 C++ runtime source
         if: steps.cpp-cache.outputs.cache-hit != 'true' && steps.antlr4-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

`1.9.X` counterpart of #788 (which targets `main`). A `pull_request` branch filter is matched against the **base** branch, so for PRs targeting `1.9.X` to trigger CI, the workflow files **on `1.9.X`** must carry the change — #788 only covers branches cut from `main`.

On `1.9.X` the `1.9.X` branch trigger is **already present** in all four workflows, so the only outstanding part of #787 here is the Ubuntu 24.04 workflow's hand-maintained `pip --no-dependencies` pins, which had drifted behind `poetry.lock` (e.g. installing `pysdmx==1.9.0` while the project requires `>=1.15.1`):

| Package | Before | After |
| --- | --- | --- |
| pyarrow | 14.0.2 | 24.0.0 |
| msgspec | 0.19.0 | 0.21.1 |
| duckdb | 1.4.1 | 1.4.4 |
| pysdmx | 1.9.0 | 1.15.1 |
| sdmxschemas | 1.0.0 | 1.0.0 (unchanged) |
| parsy | 2.2 | 2.2 (unchanged) |

The new pins match `1.9.X`'s `poetry.lock` exactly. `1.9.X`'s dual-backend test steps (pandas + duckdb) and all other workflow content are left untouched — this is a single-file, pins-only change.

## Checklist

- [ ] Code quality checks pass (`ruff format`, `ruff check`, `mypy`) — N/A, no Python changed
- [ ] Tests pass (`pytest`) — N/A, no Python changed
- [ ] Documentation updated (if applicable) — N/A
- [x] Workflow YAML validated (parses cleanly); new pip pins verified against `1.9.X`'s `poetry.lock`

## Impact / Risk

- **Breaking changes?** No — CI configuration only.
- **Data/SDMX compatibility concerns?** None. The new pins match the versions already resolved in `1.9.X`'s `poetry.lock`/`pyproject.toml`.
- **Notes for release/changelog?** CI/workflows maintenance for the 1.9.x line.

## Notes

- Branch triggers were **not** modified here — `1.9.X` already lists itself in `ubuntu_test_24_04.yml`, `testing.yml`, `version.yml`, and `docs.yml`. This PR is therefore narrower than #788.
- This PR targets the non-default branch `1.9.X`, so the `Fixes #787` keyword links it for release-notes categorization without auto-closing the issue (auto-close only fires from the default branch, via #788).

Fixes #787
