### PR TITLE
Fix #785 (1.9.X): Stop swallowing parse errors in create_ast_with_comments

### DIFF
--- a/src/vtlengine/AST/ASTComment.py
+++ b/src/vtlengine/AST/ASTComment.py
@@ -55,12 +55,11 @@ def create_ast_with_comments(text: str) -> Start:
 
     comments = [generate_ast_comment(c) for c in comment_tokens]
 
-    # Try to parse: if no statements, it's only comments
-    try:
-        ast = create_ast(text)
-        if not ast.children:
-            ast = Start(line_start=1, line_stop=1, column_start=0, column_stop=0, children=[])
-    except Exception:
+    # Parse the statements. A script with no statements (only comments or empty) yields a
+    # Start node with no children; a malformed script raises VTLSyntaxError, which must
+    # propagate instead of being silently swallowed into an empty AST.
+    ast = create_ast(text)
+    if not ast.children:
         ast = Start(line_start=1, line_stop=1, column_start=0, column_stop=0, children=[])
 
     ast.children.extend(comments)

--- a/tests/AST/test_AST.py
+++ b/tests/AST/test_AST.py
@@ -45,7 +45,7 @@ from vtlengine.AST import (
 from vtlengine.AST.ASTEncoders import ComplexDecoder, ComplexEncoder
 from vtlengine.AST.ASTTemplate import ASTTemplate
 from vtlengine.DataTypes import ScalarType
-from vtlengine.Exceptions import SemanticError
+from vtlengine.Exceptions import SemanticError, VTLSyntaxError
 from vtlengine.Interpreter import InterpreterAnalyzer
 
 base_path = Path(__file__).parent
@@ -971,3 +971,13 @@ def test_create_ast_with_comments_empty_script(script):
     ast = create_ast_with_comments(text=script)
     assert isinstance(ast, Start)
     assert all(isinstance(child, Comment) for child in ast.children)
+
+
+def test_create_ast_with_comments_syntax_error_raises():
+    script = (
+        "define hierarchical ruleset MY_HR (valuedomain rule SECTOR) is\n"
+        "    10A = 10B + 10C\n"
+        "end hierarchical ruleset;"
+    )
+    with pytest.raises(VTLSyntaxError):
+        create_ast_with_comments(text=script)


### PR DESCRIPTION
## Summary

1.9.X backport of the #785 fix (main: #791).

`prettify()` / `create_ast_with_comments()` silently returned an empty AST when a script failed to parse — e.g. a hierarchical ruleset with code items starting with a digit (`10A = 10B + 10C`). The culprit was a broad `try/except Exception` in `create_ast_with_comments` that swallowed every error from `create_ast`.

`create_ast` already raises a descriptive `VTLSyntaxError` (with line/column + caret); it was just being eaten. The original intent of that block (back in #408) was only to handle comment-only scripts gracefully — that got over-broadened into "swallow everything" during the C++ parser migration (#588).

This drops the bare `except` and lets real errors propagate. Comment-only/empty scripts still work via the existing `if not ast.children` check.

For the record: unquoted digit-starting identifiers aren't valid VTL 2.2 (verified against the official grammar — `ID_PART` must start with a letter/underscore; in VTL 2.1 the grammar still allowed digit-starting names, which is why this worked before the 2.2 alignment). The correct form is the single-quoted `'10A'`, which parses fine.

Closes #785

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — 5015 passed, added a regression test
- [ ] Documentation updated (if applicable) — n/a

## Impact / Risk

- **Behavior change:** `prettify()` / `create_ast_with_comments()` now raise instead of returning an empty AST on unparseable scripts. They also now surface `SemanticError` (dependency cycles, duplicate assignments) that were previously swallowed — these never actually formatted before (they returned empty), so no capability is lost.
- `create_ast_with_comments` is part of the public API, so this is a (correctness-improving) behavior change worth a changelog note.
- `run` / `semantic_analysis` / `run_sdmx` are unaffected — they use `create_ast` directly, which already raised.

## Notes

Out of scope: whether `prettify` (a formatter) should tolerate parseable-but-semantically-invalid scripts. That's a pre-existing coupling (`prettify` → `create_ast` → DAG analysis), not introduced here.