### PR TITLE
Fix #784 1.9.X: Preserve explicit component role op in ASTString

### DIFF
--- a/src/vtlengine/AST/ASTConstructorModules/Expr.py
+++ b/src/vtlengine/AST/ASTConstructorModules/Expr.py
@@ -1728,7 +1728,7 @@ class Expr:
             base_index = 1
         else:
             base_index = 0
-            role = Role.MEASURE
+            role = None
 
         left_node = Terminals().visitSimpleComponentId(ctx_list[base_index])
         op_node = ":="
@@ -2008,11 +2008,13 @@ class Expr:
                 left=left_node, op=op_node, right=right_node, **extract_token_info(ctx)
             )
             if role is None:
-                return UnaryOp(
+                implicit_node = UnaryOp(
                     op=Role.MEASURE.value.lower(),
                     operand=operand_node,
                     **extract_token_info(c),
                 )
+                implicit_node.is_implicit_role = True
+                return implicit_node
             return UnaryOp(op=role.value.lower(), operand=operand_node, **extract_token_info(c))
         else:
             left_node = Terminals().visitSimpleComponentId(c)
@@ -2022,11 +2024,13 @@ class Expr:
             operand_node = Assignment(
                 left=left_node, op=op_node, right=right_node, **extract_token_info(ctx)
             )
-            return UnaryOp(
+            node = UnaryOp(
                 op=Role.MEASURE.value.lower(),
                 operand=operand_node,
                 **extract_token_info(ctx),
             )
+            node.is_implicit_role = True
+            return node
 
     def visitKeepOrDropClause(self, ctx: Any) -> RegularAggregation:
         """

--- a/src/vtlengine/AST/ASTString.py
+++ b/src/vtlengine/AST/ASTString.py
@@ -314,13 +314,14 @@ class ASTString(ASTTemplate):
         is_first = self.is_first_assignment
         if is_first:
             self.is_first_assignment = False
-        if self.pretty:
-            if is_first:
-                expression = f"{self.visit(node.left)} {node.op}{nl}{tab}{self.visit(node.right)}"
-            else:
-                expression = f"{self.visit(node.left)} {node.op} {self.visit(node.right)}"
+        left = self.visit(node.left)
+        role = getattr(node.left, "role", None)
+        if role is not None:
+            left = f"{role.value.lower()} {left}"
+        if self.pretty and is_first:
+            expression = f"{left} {node.op}{nl}{tab}{self.visit(node.right)}"
         else:
-            expression = f"{self.visit(node.left)} {node.op} {self.visit(node.right)}"
+            expression = f"{left} {node.op} {self.visit(node.right)}"
         if return_element:
             return expression
         self.vtl_script += f"{expression};"
@@ -344,7 +345,9 @@ class ASTString(ASTTemplate):
         elif node.op in [IDENTIFIER, ATTRIBUTE, VIRAL_ATTRIBUTE, NOT]:
             return f"{node.op} {self.visit(node.operand)}"
         elif node.op == MEASURE:
-            return self.visit(node.operand)
+            if getattr(node, "is_implicit_role", False):
+                return self.visit(node.operand)
+            return f"{node.op} {self.visit(node.operand)}"
 
         return f"{node.op}({self.visit(node.operand)})"
 

--- a/tests/AST/data/prettier/reference_complete_grammar.vtl
+++ b/tests/AST/data/prettier/reference_complete_grammar.vtl
@@ -530,7 +530,7 @@ identifier_ds :=
 		[calc identifier Id_4 := nvl(Me_int, 0)];
 measure_ds :=
 	DS_1
-		[calc Me_new := Me_num * 5];
+		[calc measure Me_new := Me_num * 5];
 attribute_ds :=
 	DS_1
 		[calc attribute At_new := "new"];

--- a/tests/AST/data/vtl/component_roles.vtl
+++ b/tests/AST/data/vtl/component_roles.vtl
@@ -1,0 +1,8 @@
+aggr_measure_ds := DS_1 [ aggr measure Me_1 := min ( Me_1 ) group by Id_1 ];
+aggr_identifier_ds := DS_1 [ aggr identifier Me_1 := min ( Me_1 ) group by Id_1 ];
+aggr_attribute_ds := DS_1 [ aggr attribute Me_1 := min ( Me_1 ) group by Id_1 ];
+calc_measure_ds := DS_1 [ calc measure Me_3 := Me_1 + Me_2 ];
+calc_identifier_ds := DS_1 [ calc identifier Me_3 := Me_1 + Me_2 ];
+calc_attribute_ds := DS_1 [ calc attribute Me_3 := Me_1 + Me_2 ];
+aggr_implicit_measure_ds := DS_1 [ aggr Me_1 := min ( Me_1 ) group by Id_1 ];
+calc_implicit_measure_ds := DS_1 [ calc Me_3 := Me_1 + Me_2 ];

--- a/tests/AST/test_AST_String.py
+++ b/tests/AST/test_AST_String.py
@@ -29,6 +29,7 @@ params = [
     "viral_propagation.vtl",
     "round_with_slash.vtl",
     "trunc_with_slash.vtl",
+    "component_roles.vtl",
 ]
 
 params_prettier = [


### PR DESCRIPTION
## Summary

Forward-port of #786 (1.6.X) to 1.9.X.

`ASTString` dropped an explicit `measure` role keyword when rendering `calc`/`aggr` clause items, so a script written as `DS_1[calc measure Me := ...]` round-tripped/prettified back to `DS_1[calc Me := ...]` — losing the explicit role the user wrote (`identifier`/`attribute` were already preserved).

The fix marks implicitly-defaulted measure roles with an `is_implicit_role` flag during AST construction (`Expr.py`), so `ASTString` can tell an explicit `measure` from an implicit default and keep the keyword. Assignment-based `aggr` clause items carry the role on `node.left.role` and are handled in `visit_Assignment`.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — full suite: 5019 passed, 27 skipped
- [ ] Documentation updated (if applicable)

## Impact / Risk

- No API/behavior change beyond ASTString/prettify output fidelity for explicit `measure` roles.
- `is_implicit_role` is a dynamic attribute not part of AST equality, so AST round-trip semantics are unchanged.

## Notes

Adapted to the 1.9.X parser/code layout (multi-line `UnaryOp` construction, `visit_Assignment`); 1.9.X-only features (viral propagation, string_distance, join `nvl`) left untouched. A `main` forward-port PR follows.
