### PR TITLE
Fix #806: Empty viral attribute column in (in/not_in) operator

### DIFF
--- a/src/vtlengine/Operators/__init__.py
+++ b/src/vtlengine/Operators/__init__.py
@@ -777,7 +777,7 @@ class Binary(Operator):
                     dataset.data[measure_name], scalar_set
                 )
 
-        cols_to_keep = dataset.get_identifiers_names() + dataset.get_measures_names()
+        cols_to_keep = [c.name for c in dataset.get_components() if c.role != Role.ATTRIBUTE]
         result_dataset.data = result_data[cols_to_keep]
         cls.modify_measure_column(result_dataset)
 

--- a/tests/ViralAttributes/test_viral_operators.py
+++ b/tests/ViralAttributes/test_viral_operators.py
@@ -206,6 +206,25 @@ class TestViralAttributeStringParameterizedOps:
             assert list(result["DS_r"].data[va_name]) == VA_VALUES[i]
 
 
+# -- Set comparison operators (in / not_in) --
+
+
+class TestViralAttributeCompOps:
+    """Viral attributes must keep BOTH their component role and their data values
+    through the operators ``in`` and ``not_in``."""
+
+    @pytest.mark.parametrize("expr", ["DS_1 in {10, 30}", "DS_1 not_in {10, 30}"])
+    @pytest.mark.parametrize("num_viral", [1, 2, 3])
+    def test_set_membership_preserves_viral_attrs(self, expr: str, num_viral: int) -> None:
+        result = _run_single(expr, num_viral)
+        _assert_viral_attrs(result, num_viral)
+        # The viral attribute data values must be carried over unchanged.
+        for i in range(num_viral):
+            va_name = VA_NAMES[i]
+            assert va_name in result["DS_r"].data.columns, f"{va_name} missing from result data"
+            assert list(result["DS_r"].data[va_name]) == VA_VALUES[i]
+
+
 # -- Special cases --
 
 


### PR DESCRIPTION
## Summary

In and not in operators now return viral attr data cols.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)
