### PR TITLE
Fix #808: aggr, if and case operators do not return viral attr

### DIFF
--- a/src/vtlengine/Interpreter/__init__.py
+++ b/src/vtlengine/Interpreter/__init__.py
@@ -577,7 +577,7 @@ class InterpreterAnalyzer(ASTTemplate):
                     comp_name,
                     comp,
                 ) in self.regular_aggregation_dataset.components.items():
-                    if comp.role == Role.IDENTIFIER:
+                    if comp.role in (Role.IDENTIFIER, Role.VIRAL_ATTRIBUTE):
                         comps_to_keep[comp_name] = copy(comp)
                 comps_to_keep[op_comp.name] = Component(
                     name=op_comp.name,
@@ -586,7 +586,10 @@ class InterpreterAnalyzer(ASTTemplate):
                     nullable=op_comp.nullable,
                 )
                 if operand.data is not None:
-                    data_to_keep = operand.data[operand.get_identifiers_names()]
+                    cols_to_keep = (
+                        operand.get_identifiers_names() + operand.get_viral_attributes_names()
+                    )
+                    data_to_keep = operand.data[cols_to_keep].copy()
                     data_to_keep[op_comp.name] = op_comp.data
                 else:
                     data_to_keep = None
@@ -1074,7 +1077,9 @@ class InterpreterAnalyzer(ASTTemplate):
                 if comp.role != Role.MEASURE
             }
             if dataset.data is not None:
-                dataset.data = dataset.data[dataset.get_identifiers_names()]
+                dataset.data = dataset.data[
+                    dataset.get_identifiers_names() + dataset.get_viral_attributes_names()
+                ]
             aux_operands = []
             for operand in operands:
                 measure = operand.get_component(operand.get_measures_names()[0])

--- a/src/vtlengine/Operators/Conditional.py
+++ b/src/vtlengine/Operators/Conditional.py
@@ -96,6 +96,7 @@ class If(Operator):
         cond_measure = condition.get_measures_names()[0]
         cond = condition.data
         cond[COND_COL] = cond.pop(cond_measure).fillna(False).astype("bool[pyarrow]")
+        cond = cond[ids + [COND_COL]]
 
         t_base = dataset_assign(cond[cond[COND_COL]], true_branch, ids, measures)
         f_base = dataset_assign(cond[~cond[COND_COL]], false_branch, ids, measures)
@@ -346,6 +347,7 @@ class Case(Operator):
             case = conditions[i].data.rename(
                 columns={conditions[i].get_measures_names()[0]: COND_COL}
             )
+            case = case[ids + [COND_COL]]
             case_result = dataset_assign(
                 case[case[COND_COL].fillna(False)], thenOps[i], ids, measures
             )

--- a/src/vtlengine/Operators/Conditional.py
+++ b/src/vtlengine/Operators/Conditional.py
@@ -13,6 +13,7 @@ from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import DataComponent, Dataset, Role, Scalar
 from vtlengine.Operators import Binary, Operator
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
+from vtlengine.ViralPropagation import get_current_registry
 
 COND_COL = "__cond__"
 
@@ -32,6 +33,42 @@ def dataset_assign(
             return pd.DataFrame(columns=ids + measures + [COND_COL])
         return cond.merge(op.data, on=ids, how="inner")
     return cond.assign(**dict.fromkeys(measures, op.value))
+
+
+def _combine_viral_attributes(result: Any, operands: List[Any]) -> None:
+    """Combine the viral attributes, as the viral attribute binary combination"""
+    if not isinstance(result, Dataset) or result.data is None:
+        return
+    res_data = result.data
+    ds_ops = [op for op in operands if isinstance(op, Dataset) and op.data is not None]
+    if len(ds_ops) < 2:
+        return
+    registry = get_current_registry()
+    ids = result.get_identifiers_names()
+    n = len(res_data)
+    for va in result.get_viral_attributes_names():
+        carriers: List[pd.DataFrame] = [
+            op.data
+            for op in ds_ops
+            if op.data is not None
+            and va in op.get_viral_attributes_names()
+            and va in op.data.columns
+        ]
+        if len(carriers) < 2:
+            continue
+        if ids:
+            base = res_data[ids]
+            cols = [
+                list(
+                    base.merge(d[ids + [va]].rename(columns={va: "__v__"}), on=ids, how="left")[
+                        "__v__"
+                    ]
+                )
+                for d in carriers
+            ]
+        else:
+            cols = [list(d[va]) for d in carriers]
+        res_data[va] = [registry.resolve_group(va, [col[r] for col in cols]) for r in range(n)]
 
 
 class If(Operator):
@@ -109,6 +146,7 @@ class If(Operator):
                 t_base[col] = t_base[col].astype(common_dtype)
                 f_base[col] = f_base[col].astype(common_dtype)
         result.data = t_base.merge(f_base, how="outer").drop(columns=COND_COL)
+        _combine_viral_attributes(result, [true_branch, false_branch])
 
     @classmethod
     def validate(  # noqa: C901
@@ -241,6 +279,7 @@ class Nvl(Binary):
                         result.data = left.data.fillna(right.value)
                 else:
                     result.data = left.data.fillna(right.data)
+                    _combine_viral_attributes(result, [left, right])
                 if isinstance(result, Dataset):
                     result.data = result.data[result.get_components_names()]
         return result
@@ -356,6 +395,7 @@ class Case(Operator):
             )
 
         result.data.drop(columns=COND_COL, inplace=True)
+        _combine_viral_attributes(result, [*thenOps, elseOp])
 
     @classmethod
     def validate(

--- a/src/vtlengine/ViralPropagation/__init__.py
+++ b/src/vtlengine/ViralPropagation/__init__.py
@@ -100,14 +100,13 @@ class ViralPropagationRegistry:
 
     def resolve_group(self, variable_name: str, values: List[Any]) -> Any:
         """Resolve N values (for aggregation/analytic operators)."""
-        rule = self.get_rule_for_variable(variable_name)
-        if rule is None:
-            return None
-
         if len(values) == 0:
             return None
         if len(values) == 1:
             return values[0]
+        rule = self.get_rule_for_variable(variable_name)
+        if rule is None:
+            return None
 
         if rule.aggregate_function is not None:
             funcs: Dict[str, Any] = {

--- a/src/vtlengine/ViralPropagation/sql.py
+++ b/src/vtlengine/ViralPropagation/sql.py
@@ -85,3 +85,8 @@ def vp_group_sql_windowed(rule: ViralPropagationRule, col_ref: str, over_clause:
         return f"{_AGG_GROUP[rule.aggregate_function]}({col_ref}) OVER ({over_clause})"
     case = _enumerated_case(rule, "acc", "x")
     return f"list_reduce(list({col_ref}) OVER ({over_clause}), (acc, x) -> {case})"
+
+
+def vp_no_rule_group_sql(col_ref: str) -> str:
+    """Group no-rule keep: copy the value of a single-row group, else NULL."""
+    return f"CASE WHEN COUNT(*) = 1 THEN MAX({col_ref}) ELSE NULL END"

--- a/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
+++ b/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
@@ -49,6 +49,7 @@ from vtlengine.ViralPropagation import get_current_registry
 from vtlengine.ViralPropagation.sql import (
     vp_group_sql,
     vp_group_sql_windowed,
+    vp_no_rule_group_sql,
     vp_pair_sql,
     vp_reduce_refs,
 )
@@ -1874,6 +1875,17 @@ FROM (
         for col_name, expr_sql in calc_exprs.items():
             cols.append(f"{expr_sql} AS {quote_name(col_name)}")
 
+        vp_registry = get_current_registry()
+        for v_name, v_comp in ds.components.items():
+            if v_comp.role != Role.VIRAL_ATTRIBUTE:
+                continue
+            v_rule = vp_registry.rule_for(v_comp)
+            v_qn = quote_name(v_name)
+            if v_rule is None:
+                cols.append(f"{vp_no_rule_group_sql(v_qn)} AS {v_qn}")
+            else:
+                cols.append(f"{vp_group_sql(v_rule, v_qn)} AS {v_qn}")
+
         builder = SQLBuilder().select(*cols).from_table(table_src)
         if group_ids:
             builder.group_by(*[_id_group_sql(id_) for id_ in group_ids])
@@ -2076,7 +2088,7 @@ FROM (
             v_rule = vp_registry.rule_for(v_comp)
             v_qn = quote_name(v_name)
             if v_rule is None:
-                cols.append(f"CAST(NULL AS {get_duckdb_type(v_comp.data_type.__name__)}) AS {v_qn}")
+                cols.append(f"{vp_no_rule_group_sql(v_qn)} AS {v_qn}")
             else:
                 cols.append(f"{vp_group_sql(v_rule, v_qn)} AS {v_qn}")
 
@@ -2225,7 +2237,7 @@ FROM (
         def _viral_expr(v_name: str, v_comp: Any) -> str:
             v_rule = vp_registry.rule_for(v_comp)
             if v_rule is None:
-                return quote_name(v_name)  # single value per row -> pass through
+                return quote_name(v_name)
             return vp_group_sql_windowed(v_rule, quote_name(v_name), vp_over_clause)
 
         name_override = "int_var" if op == tokens.COUNT else None
@@ -2501,6 +2513,7 @@ FROM (
             ref_ds = self._get_output_dataset() or source_ds
         output_measures = list(ref_ds.get_measures_names())
         output_attributes = list(ref_ds.get_attributes_names())
+        output_viral = list(ref_ds.get_viral_attributes_names())
 
         # Build SELECT columns
         cols: List[str] = [f"{alias}.{quote_name(id_)}" for id_ in source_ids]
@@ -2510,6 +2523,22 @@ FROM (
             cols.append(
                 f"CASE WHEN {cond_expr} THEN {t_ref} ELSE {e_ref} END AS {quote_name(col_name)}"
             )
+
+        vp_registry = get_current_registry()
+        for v_name in output_viral:
+            v_qn = quote_name(v_name)
+            v_comp = ref_ds.components.get(v_name)
+            if t_type == _DATASET and e_type == _DATASET:
+                v_rule = vp_registry.rule_for(v_comp) if v_comp is not None else None
+                if v_rule is None:
+                    v_type = get_duckdb_type(v_comp.data_type.__name__) if v_comp else "VARCHAR"
+                    cols.append(f"CAST(NULL AS {v_type}) AS {v_qn}")
+                else:
+                    cols.append(f"{vp_pair_sql(v_rule, f't.{v_qn}', f'e.{v_qn}')} AS {v_qn}")
+            elif t_type == _DATASET:
+                cols.append(f"CASE WHEN {cond_expr} THEN t.{v_qn} ELSE NULL END AS {v_qn}")
+            elif e_type == _DATASET:
+                cols.append(f"CASE WHEN {cond_expr} THEN NULL ELSE e.{v_qn} END AS {v_qn}")
 
         # Use from_subquery when the source is a SELECT (e.g., dataset-level condition)
         if source_sql.lstrip().upper().startswith("SELECT"):
@@ -2598,6 +2627,7 @@ FROM (
 
         output_ds = self._get_output_dataset() or source_ds
         output_measures = output_ds.get_measures_names()
+        output_viral = output_ds.get_viral_attributes_names()
         builder = SQLBuilder().from_table(source_sql, alias_src)
 
         # Process each WHEN branch
@@ -2623,7 +2653,6 @@ FROM (
         if e_type == _DATASET:
             self._left_join_dataset(node.elseOp, e_type, e_alias, source_ids, alias_src, builder)
 
-        # Build SELECT: identifiers + CASE WHEN per measure (reversed for last-match-wins)
         cols: List[str] = [f"{alias_src}.{quote_name(id_)}" for id_ in source_ids]
         for measure in output_measures:
             case_parts = ["CASE"]
@@ -2641,6 +2670,23 @@ FROM (
             )
             case_parts.append(f"ELSE {else_ref} END")
             cols.append(f"{' '.join(case_parts)} AS {quote_name(measure)}")
+
+        vp_registry = get_current_registry()
+        for v_name in output_viral:
+            v_qn = quote_name(v_name)
+            v_comp = output_ds.components.get(v_name)
+            refs = [f"{then_aliases[i]}.{v_qn}" for i in range(len(node.cases)) if then_aliases[i]]
+            if e_type == _DATASET:
+                refs.append(f"{e_alias}.{v_qn}")
+            if len(refs) >= 2:
+                v_rule = vp_registry.rule_for(v_comp) if v_comp is not None else None
+                if v_rule is None:
+                    v_type = get_duckdb_type(v_comp.data_type.__name__) if v_comp else "VARCHAR"
+                    cols.append(f"CAST(NULL AS {v_type}) AS {v_qn}")
+                else:
+                    cols.append(f"{vp_reduce_refs(v_rule, refs)} AS {v_qn}")
+            elif refs:
+                cols.append(f"{refs[0]} AS {v_qn}")
 
         builder.select(*cols)
 

--- a/tests/ViralAttributes/test_viral_operators.py
+++ b/tests/ViralAttributes/test_viral_operators.py
@@ -181,8 +181,11 @@ class TestViralAttributeOtherOps:
             "DS_1[aggr Me_3 := max(Me_1) group by Id_1]",
         ],
     )
+    @pytest.mark.parametrize("use_duckdb", [False, True])
     @pytest.mark.parametrize("num_viral", [1, 2, 3])
-    def test_aggr_clause_preserves_viral_attrs(self, expr: str, num_viral: int) -> None:
+    def test_aggr_clause_preserves_viral_attrs(
+        self, expr: str, num_viral: int, use_duckdb: bool
+    ) -> None:
         comps = [
             {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
             {"name": "Id_2", "type": "Integer", "role": "Identifier", "nullable": False},
@@ -199,6 +202,7 @@ class TestViralAttributeOtherOps:
             script=f"DS_r <- {expr};",
             data_structures={"datasets": [{"name": "DS_1", "DataStructure": comps}]},
             datapoints={"DS_1": pd.DataFrame(data)},
+            use_duckdb=use_duckdb,
         )
         _assert_viral_attrs(result, num_viral)
         # The viral attribute column must survive the aggr clause (component/data parity).
@@ -214,10 +218,15 @@ class TestViralAttributeConditionalOps:
 
     The condition dataset (e.g. ``DS_1#Id_2 = "A"``) also carries the viral
     attribute, which previously collided on merge with the branch operands and
-    corrupted the result (component/data mismatch -> downstream crash)."""
+    corrupted the result (component/data mismatch -> downstream crash). The
+    viral attribute itself combines across branches like a binary operator: with
+    no propagation rule its combined value is NULL."""
 
+    @pytest.mark.parametrize("use_duckdb", [False, True])
     @pytest.mark.parametrize("num_viral", [1, 2, 3])
-    def test_if_dataset_condition_preserves_viral_attrs(self, num_viral: int) -> None:
+    def test_if_dataset_condition_preserves_viral_attrs(
+        self, num_viral: int, use_duckdb: bool
+    ) -> None:
         comps = [
             {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
             {"name": "Id_2", "type": "String", "role": "Identifier", "nullable": False},
@@ -234,13 +243,17 @@ class TestViralAttributeConditionalOps:
             script='DS_r <- if DS_1#Id_2 = "A" then DS_1 else DS_1;',
             data_structures={"datasets": [{"name": "DS_1", "DataStructure": comps}]},
             datapoints={"DS_1": pd.DataFrame(data)},
+            use_duckdb=use_duckdb,
         )
         _assert_viral_attrs(result, num_viral)
-        for va_name in VA_NAMES[:num_viral]:
-            assert va_name in result["DS_r"].data.columns, f"{va_name} missing from result data"
+        _assert_component_data_parity(result)
+        for i in range(num_viral):
+            va = VA_NAMES[i]
+            assert result["DS_r"].data[va].isna().all()
 
+    @pytest.mark.parametrize("use_duckdb", [False, True])
     @pytest.mark.parametrize("num_viral", [1, 2, 3])
-    def test_count_over_if_dataset_condition(self, num_viral: int) -> None:
+    def test_count_over_if_dataset_condition(self, num_viral: int, use_duckdb: bool) -> None:
         """count() over an if-then-else result must not crash on viral attrs."""
         comps = [
             {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
@@ -258,14 +271,18 @@ class TestViralAttributeConditionalOps:
             script='DS_r <- count(if DS_1#Id_2 = "A" then DS_1 else DS_1 group by Id_1);',
             data_structures={"datasets": [{"name": "DS_1", "DataStructure": comps}]},
             datapoints={"DS_1": pd.DataFrame(data)},
+            use_duckdb=use_duckdb,
         )
         _assert_viral_attrs(result, num_viral)
         for va_name in VA_NAMES[:num_viral]:
             assert va_name in result["DS_r"].data.columns, f"{va_name} missing from result data"
 
+    @pytest.mark.parametrize("use_duckdb", [False, True])
     @pytest.mark.parametrize("num_viral", [1, 2, 3])
-    def test_case_dataset_condition_preserves_viral_attrs(self, num_viral: int) -> None:
-        """A dataset-level ``case`` must not leave phantom suffixed viral columns."""
+    def test_case_dataset_condition_preserves_viral_attrs(
+        self, num_viral: int, use_duckdb: bool
+    ) -> None:
+        """A dataset-level ``case`` keeps viral attrs (1:1) with no phantom columns."""
         comps = [
             {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
             {"name": "Id_2", "type": "String", "role": "Identifier", "nullable": False},
@@ -282,16 +299,18 @@ class TestViralAttributeConditionalOps:
             script='DS_r <- case when DS_1#Id_2 = "A" then DS_1 else DS_1;',
             data_structures={"datasets": [{"name": "DS_1", "DataStructure": comps}]},
             datapoints={"DS_1": pd.DataFrame(data)},
+            use_duckdb=use_duckdb,
         )
         _assert_viral_attrs(result, num_viral)
         _assert_component_data_parity(result)
 
+    @pytest.mark.parametrize("use_duckdb", [False, True])
     @pytest.mark.parametrize(
         "expr",
         ["nvl(DS_1, DS_2)", "nvl(DS_1, 0.0)"],
     )
     @pytest.mark.parametrize("num_viral", [1, 2, 3])
-    def test_nvl_preserves_viral_attrs(self, expr: str, num_viral: int) -> None:
+    def test_nvl_preserves_viral_attrs(self, expr: str, num_viral: int, use_duckdb: bool) -> None:
         comps = BASE_COMPS + VA_COMPONENTS[:num_viral]
         structures = [{"name": "DS_1", "DataStructure": comps}]
         datapoints = {"DS_1": _make_dp(num_viral)}
@@ -302,6 +321,7 @@ class TestViralAttributeConditionalOps:
             script=f"DS_r <- {expr};",
             data_structures={"datasets": structures},
             datapoints=datapoints,
+            use_duckdb=use_duckdb,
         )
         _assert_viral_attrs(result, num_viral)
         _assert_component_data_parity(result)

--- a/tests/ViralAttributes/test_viral_operators.py
+++ b/tests/ViralAttributes/test_viral_operators.py
@@ -62,6 +62,15 @@ def _assert_viral_attrs(result: dict, num_viral: int) -> None:
         assert ds_r.components[va_name].role == Role.VIRAL_ATTRIBUTE
 
 
+def _assert_component_data_parity(result: dict) -> None:
+    """Assert the result data columns match the declared components exactly."""
+    ds_r = result["DS_r"]
+    assert set(ds_r.data.columns) == set(ds_r.components), (
+        f"component/data mismatch: components={sorted(ds_r.components)}, "
+        f"data={sorted(ds_r.data.columns)}"
+    )
+
+
 # -- Unary operators --
 
 unary_params = [
@@ -138,8 +147,9 @@ class TestViralAttributeOtherOps:
         result = _run_pair("intersect(DS_1, DS_2)", num_viral)
         _assert_viral_attrs(result, num_viral)
 
+    @pytest.mark.parametrize("agg_op", ["sum", "avg", "count", "min", "max"])
     @pytest.mark.parametrize("num_viral", [1, 2, 3])
-    def test_aggregation_preserves_viral_attrs(self, num_viral: int) -> None:
+    def test_aggregation_preserves_viral_attrs(self, agg_op: str, num_viral: int) -> None:
         comps = [
             {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
             {"name": "Id_2", "type": "Integer", "role": "Identifier", "nullable": False},
@@ -153,11 +163,148 @@ class TestViralAttributeOtherOps:
         for i in range(num_viral):
             data[VA_NAMES[i]] = [VA_VALUES[i][0], VA_VALUES[i][0], VA_VALUES[i][1]]
         result = run(
-            script="DS_r <- sum(DS_1 group by Id_1);",
+            script=f"DS_r <- {agg_op}(DS_1 group by Id_1);",
             data_structures={"datasets": [{"name": "DS_1", "DataStructure": comps}]},
             datapoints={"DS_1": pd.DataFrame(data)},
         )
         _assert_viral_attrs(result, num_viral)
+        for va_name in VA_NAMES[:num_viral]:
+            assert va_name in result["DS_r"].data.columns, f"{va_name} missing from result data"
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "DS_1[aggr Me_3 := count() group by Id_1]",
+            "DS_1[aggr Me_3 := sum(Me_1) group by Id_1]",
+            "DS_1[aggr Me_3 := avg(Me_1) group by Id_1]",
+            "DS_1[aggr Me_3 := min(Me_1) group by Id_1]",
+            "DS_1[aggr Me_3 := max(Me_1) group by Id_1]",
+        ],
+    )
+    @pytest.mark.parametrize("num_viral", [1, 2, 3])
+    def test_aggr_clause_preserves_viral_attrs(self, expr: str, num_viral: int) -> None:
+        comps = [
+            {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+            {"name": "Id_2", "type": "Integer", "role": "Identifier", "nullable": False},
+            {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+        ] + VA_COMPONENTS[:num_viral]
+        data: dict = {
+            "Id_1": [1, 1, 2],
+            "Id_2": [1, 2, 1],
+            "Me_1": [10.0, 20.0, 30.0],
+        }
+        for i in range(num_viral):
+            data[VA_NAMES[i]] = [VA_VALUES[i][0], VA_VALUES[i][0], VA_VALUES[i][1]]
+        result = run(
+            script=f"DS_r <- {expr};",
+            data_structures={"datasets": [{"name": "DS_1", "DataStructure": comps}]},
+            datapoints={"DS_1": pd.DataFrame(data)},
+        )
+        _assert_viral_attrs(result, num_viral)
+        # The viral attribute column must survive the aggr clause (component/data parity).
+        for va_name in VA_NAMES[:num_viral]:
+            assert va_name in result["DS_r"].data.columns, f"{va_name} missing from result data"
+
+
+# -- Conditional operators (if-then-else) --
+
+
+class TestViralAttributeConditionalOps:
+    """Viral attributes must survive an if-then-else whose condition is a dataset.
+
+    The condition dataset (e.g. ``DS_1#Id_2 = "A"``) also carries the viral
+    attribute, which previously collided on merge with the branch operands and
+    corrupted the result (component/data mismatch -> downstream crash)."""
+
+    @pytest.mark.parametrize("num_viral", [1, 2, 3])
+    def test_if_dataset_condition_preserves_viral_attrs(self, num_viral: int) -> None:
+        comps = [
+            {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+            {"name": "Id_2", "type": "String", "role": "Identifier", "nullable": False},
+            {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+        ] + VA_COMPONENTS[:num_viral]
+        data: dict = {
+            "Id_1": [1, 1, 2],
+            "Id_2": ["A", "B", "A"],
+            "Me_1": [10.0, 20.0, 30.0],
+        }
+        for i in range(num_viral):
+            data[VA_NAMES[i]] = [VA_VALUES[i][0], VA_VALUES[i][0], VA_VALUES[i][1]]
+        result = run(
+            script='DS_r <- if DS_1#Id_2 = "A" then DS_1 else DS_1;',
+            data_structures={"datasets": [{"name": "DS_1", "DataStructure": comps}]},
+            datapoints={"DS_1": pd.DataFrame(data)},
+        )
+        _assert_viral_attrs(result, num_viral)
+        for va_name in VA_NAMES[:num_viral]:
+            assert va_name in result["DS_r"].data.columns, f"{va_name} missing from result data"
+
+    @pytest.mark.parametrize("num_viral", [1, 2, 3])
+    def test_count_over_if_dataset_condition(self, num_viral: int) -> None:
+        """count() over an if-then-else result must not crash on viral attrs."""
+        comps = [
+            {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+            {"name": "Id_2", "type": "String", "role": "Identifier", "nullable": False},
+            {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+        ] + VA_COMPONENTS[:num_viral]
+        data: dict = {
+            "Id_1": [1, 1, 2],
+            "Id_2": ["A", "B", "A"],
+            "Me_1": [10.0, 20.0, 30.0],
+        }
+        for i in range(num_viral):
+            data[VA_NAMES[i]] = [VA_VALUES[i][0], VA_VALUES[i][0], VA_VALUES[i][1]]
+        result = run(
+            script='DS_r <- count(if DS_1#Id_2 = "A" then DS_1 else DS_1 group by Id_1);',
+            data_structures={"datasets": [{"name": "DS_1", "DataStructure": comps}]},
+            datapoints={"DS_1": pd.DataFrame(data)},
+        )
+        _assert_viral_attrs(result, num_viral)
+        for va_name in VA_NAMES[:num_viral]:
+            assert va_name in result["DS_r"].data.columns, f"{va_name} missing from result data"
+
+    @pytest.mark.parametrize("num_viral", [1, 2, 3])
+    def test_case_dataset_condition_preserves_viral_attrs(self, num_viral: int) -> None:
+        """A dataset-level ``case`` must not leave phantom suffixed viral columns."""
+        comps = [
+            {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+            {"name": "Id_2", "type": "String", "role": "Identifier", "nullable": False},
+            {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+        ] + VA_COMPONENTS[:num_viral]
+        data: dict = {
+            "Id_1": [1, 1, 2],
+            "Id_2": ["A", "B", "A"],
+            "Me_1": [10.0, 20.0, 30.0],
+        }
+        for i in range(num_viral):
+            data[VA_NAMES[i]] = [VA_VALUES[i][0], VA_VALUES[i][0], VA_VALUES[i][1]]
+        result = run(
+            script='DS_r <- case when DS_1#Id_2 = "A" then DS_1 else DS_1;',
+            data_structures={"datasets": [{"name": "DS_1", "DataStructure": comps}]},
+            datapoints={"DS_1": pd.DataFrame(data)},
+        )
+        _assert_viral_attrs(result, num_viral)
+        _assert_component_data_parity(result)
+
+    @pytest.mark.parametrize(
+        "expr",
+        ["nvl(DS_1, DS_2)", "nvl(DS_1, 0.0)"],
+    )
+    @pytest.mark.parametrize("num_viral", [1, 2, 3])
+    def test_nvl_preserves_viral_attrs(self, expr: str, num_viral: int) -> None:
+        comps = BASE_COMPS + VA_COMPONENTS[:num_viral]
+        structures = [{"name": "DS_1", "DataStructure": comps}]
+        datapoints = {"DS_1": _make_dp(num_viral)}
+        if "DS_2" in expr:
+            structures.append({"name": "DS_2", "DataStructure": comps})
+            datapoints["DS_2"] = _make_dp(num_viral)
+        result = run(
+            script=f"DS_r <- {expr};",
+            data_structures={"datasets": structures},
+            datapoints=datapoints,
+        )
+        _assert_viral_attrs(result, num_viral)
+        _assert_component_data_parity(result)
 
 
 # -- String parameterized operators (substr, replace, instr) --


### PR DESCRIPTION
## Summary

Aggr, if and case operators now return viral attr

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)
