### PR TITLE
Fix #812: ASTString remove single quotes

### DIFF
--- a/src/vtlengine/AST/ASTConstructor.py
+++ b/src/vtlengine/AST/ASTConstructor.py
@@ -29,7 +29,11 @@ from vtlengine.AST import (
 from vtlengine.AST.ASTConstructorModules import extract_token_info
 from vtlengine.AST.ASTConstructorModules.Expr import Expr
 from vtlengine.AST.ASTConstructorModules.ExprComponents import ExprComp
-from vtlengine.AST.ASTConstructorModules.Terminals import Terminals, _remove_scaped_characters
+from vtlengine.AST.ASTConstructorModules.Terminals import (
+    Terminals,
+    _remove_scaped_characters,
+    is_quoted_value_domain_value,
+)
 from vtlengine.AST.ASTDataExchange import de_ruleset_elements
 from vtlengine.AST.Grammar._cpp_parser import vtl_cpp_parser
 from vtlengine.AST.Grammar._cpp_parser._rule_constants import RC
@@ -606,17 +610,21 @@ class ASTVisitor:
         if ctx_list[0].is_terminal:
             when = ctx_list[0].text
             vd_value = Terminals().visitValueDomainValue(ctx_list[3])
+            vd_quoted = is_quoted_value_domain_value(ctx_list[3])
             op = Terminals().visitComparisonOperand(ctx_list[4])
             token_info_value = extract_token_info(ctx_list[3])
             token_info_op = extract_token_info(ctx_list[4])
         else:
             vd_value = Terminals().visitValueDomainValue(ctx_list[0])
+            vd_quoted = is_quoted_value_domain_value(ctx_list[0])
             op = Terminals().visitComparisonOperand(ctx_list[1])
             token_info_value = extract_token_info(ctx_list[0])
             token_info_op = extract_token_info(ctx_list[1])
 
         rule_node = HRBinOp(
-            left=DefIdentifier(value=vd_value, kind="CodeItemID", **token_info_value),
+            left=DefIdentifier(
+                value=vd_value, kind="CodeItemID", was_quoted=vd_quoted, **token_info_value
+            ),
             op=op,
             right=None,
             **token_info_op,
@@ -681,7 +689,10 @@ class ASTVisitor:
             value = Terminals().visitValueDomainValue(ctx_list[1])
 
             code_item = DefIdentifier(
-                value=value, kind="CodeItemID", **extract_token_info(ctx_list[1])
+                value=value,
+                kind="CodeItemID",
+                was_quoted=is_quoted_value_domain_value(ctx_list[1]),
+                **extract_token_info(ctx_list[1]),
             )
             if right_condition:
                 code_item._right_condition = right_condition[0]
@@ -690,7 +701,10 @@ class ASTVisitor:
         else:
             value = Terminals().visitValueDomainValue(ctx_list[0])
             code_item = DefIdentifier(
-                value=value, kind="CodeItemID", **extract_token_info(ctx_list[0])
+                value=value,
+                kind="CodeItemID",
+                was_quoted=is_quoted_value_domain_value(ctx_list[0]),
+                **extract_token_info(ctx_list[0]),
             )
             if right_condition:
                 code_item._right_condition = right_condition[0]

--- a/src/vtlengine/AST/ASTConstructor.py
+++ b/src/vtlengine/AST/ASTConstructor.py
@@ -32,7 +32,7 @@ from vtlengine.AST.ASTConstructorModules.ExprComponents import ExprComp
 from vtlengine.AST.ASTConstructorModules.Terminals import (
     Terminals,
     _remove_scaped_characters,
-    is_quoted_value_domain_value,
+    is_quoted_identifier,
 )
 from vtlengine.AST.ASTDataExchange import de_ruleset_elements
 from vtlengine.AST.Grammar._cpp_parser import vtl_cpp_parser
@@ -610,13 +610,13 @@ class ASTVisitor:
         if ctx_list[0].is_terminal:
             when = ctx_list[0].text
             vd_value = Terminals().visitValueDomainValue(ctx_list[3])
-            vd_quoted = is_quoted_value_domain_value(ctx_list[3])
+            vd_quoted = is_quoted_identifier(ctx_list[3])
             op = Terminals().visitComparisonOperand(ctx_list[4])
             token_info_value = extract_token_info(ctx_list[3])
             token_info_op = extract_token_info(ctx_list[4])
         else:
             vd_value = Terminals().visitValueDomainValue(ctx_list[0])
-            vd_quoted = is_quoted_value_domain_value(ctx_list[0])
+            vd_quoted = is_quoted_identifier(ctx_list[0])
             op = Terminals().visitComparisonOperand(ctx_list[1])
             token_info_value = extract_token_info(ctx_list[0])
             token_info_op = extract_token_info(ctx_list[1])
@@ -691,7 +691,7 @@ class ASTVisitor:
             code_item = DefIdentifier(
                 value=value,
                 kind="CodeItemID",
-                was_quoted=is_quoted_value_domain_value(ctx_list[1]),
+                was_quoted=is_quoted_identifier(ctx_list[1]),
                 **extract_token_info(ctx_list[1]),
             )
             if right_condition:
@@ -703,7 +703,7 @@ class ASTVisitor:
             code_item = DefIdentifier(
                 value=value,
                 kind="CodeItemID",
-                was_quoted=is_quoted_value_domain_value(ctx_list[0]),
+                was_quoted=is_quoted_identifier(ctx_list[0]),
                 **extract_token_info(ctx_list[0]),
             )
             if right_condition:

--- a/src/vtlengine/AST/ASTConstructorModules/Terminals.py
+++ b/src/vtlengine/AST/ASTConstructorModules/Terminals.py
@@ -33,6 +33,11 @@ def _remove_scaped_characters(text):
     return text
 
 
+def is_quoted_value_domain_value(ctx):
+    child = ctx.children[0]
+    return child.is_terminal and child.text.startswith("'")
+
+
 class Terminals:
     def visitConstant(self, ctx):
         # constant: signedInteger | signedNumber | BOOLEAN_CONSTANT |

--- a/src/vtlengine/AST/ASTConstructorModules/Terminals.py
+++ b/src/vtlengine/AST/ASTConstructorModules/Terminals.py
@@ -33,7 +33,7 @@ def _remove_scaped_characters(text):
     return text
 
 
-def is_quoted_value_domain_value(ctx):
+def is_quoted_identifier(ctx):
     child = ctx.children[0]
     return child.is_terminal and child.text.startswith("'")
 

--- a/src/vtlengine/AST/ASTString.py
+++ b/src/vtlengine/AST/ASTString.py
@@ -185,6 +185,8 @@ class ASTString(ASTTemplate):
         return f"{node.op} {self.visit(node.operand)}"
 
     def visit_DefIdentifier(self, node: AST.DefIdentifier) -> str:
+        if node.kind == "CodeItemID" and node.value[0].isdigit():
+            return f"'{node.value}'"
         return _format_reserved_word(node.value)
 
     def visit_DPRule(self, node: AST.DPRule) -> str:

--- a/src/vtlengine/AST/ASTString.py
+++ b/src/vtlengine/AST/ASTString.py
@@ -185,7 +185,7 @@ class ASTString(ASTTemplate):
         return f"{node.op} {self.visit(node.operand)}"
 
     def visit_DefIdentifier(self, node: AST.DefIdentifier) -> str:
-        if node.kind == "CodeItemID" and node.value[0].isdigit():
+        if node.was_quoted:
             return f"'{node.value}'"
         return _format_reserved_word(node.value)
 

--- a/src/vtlengine/AST/__init__.py
+++ b/src/vtlengine/AST/__init__.py
@@ -600,11 +600,11 @@ class Operator(AST):
 @dataclass
 class DefIdentifier(AST):
     """
-    DefIdentifier: (value, kind)
-    """
+    DefIdentifier: (value, kind, was_quoted)"""
 
     value: str
     kind: str
+    was_quoted: bool = False
 
     __eq__ = AST.ast_equality
 

--- a/tests/AST/data/vtl/hierarchical_quoted_codeitems.vtl
+++ b/tests/AST/data/vtl/hierarchical_quoted_codeitems.vtl
@@ -1,0 +1,3 @@
+define hierarchical ruleset HIE_IVF_REP_SECTOR_IF (valuedomain rule IVF_REP_SECTOR) is
+    HIE_IVF_REP_SECTOR_1: '10A' = '10C' + '10D' - '10B'
+end hierarchical ruleset;

--- a/tests/AST/test_AST_String.py
+++ b/tests/AST/test_AST_String.py
@@ -30,6 +30,7 @@ params = [
     "round_with_slash.vtl",
     "trunc_with_slash.vtl",
     "component_roles.vtl",
+    "hierarchical_quoted_codeitems.vtl",
 ]
 
 params_prettier = [


### PR DESCRIPTION
## Summary

ASTString now keep quoted codeItems

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)