### PR TITLE
Fix #819: null is not managed in propagation rules clause

### DIFF
--- a/src/vtlengine/ViralPropagation/__init__.py
+++ b/src/vtlengine/ViralPropagation/__init__.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from functools import reduce
 from typing import Any, Dict, List, Optional
 
+import pandas as pd
+
 
 @dataclass
 class ViralPropagationRule:
@@ -87,13 +89,13 @@ class ViralPropagationRegistry:
         binary_clauses = [c for c in rule.enumerated_clauses if len(c["values"]) == 2]
         unary_clauses = [c for c in rule.enumerated_clauses if len(c["values"]) == 1]
 
-        pair = {value_a, value_b}
+        pair = {self._normalize_null(value_a), self._normalize_null(value_b)}
         for clause in binary_clauses:
-            if set(clause["values"]) == pair:
+            if {self._normalize_null(v) for v in clause["values"]} == pair:
                 return clause["result"]
 
         for clause in unary_clauses:
-            if clause["values"][0] in pair:
+            if self._normalize_null(clause["values"][0]) in pair:
                 return clause["result"]
 
         return rule.default_value
@@ -124,6 +126,11 @@ class ViralPropagationRegistry:
         """Clear all registered rules."""
         self._variable_rules.clear()
         self._valuedomain_rules.clear()
+
+    def _normalize_null(self, value: Any) -> Any:
+        if pd.isna(value):
+            return None
+        return value
 
 
 # Module-level accessor for operators to use.

--- a/src/vtlengine/ViralPropagation/sql.py
+++ b/src/vtlengine/ViralPropagation/sql.py
@@ -6,7 +6,7 @@ or an aggregate function). This module imports nothing from the transpiler or
 the data model, so it is free of import cycles.
 """
 
-from typing import Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from vtlengine.ViralPropagation import ViralPropagationRule
 
@@ -21,9 +21,18 @@ _AGG_BINARY: Dict[str, Callable[[str, str], str]] = {
 _AGG_GROUP: Dict[str, str] = {"min": "MIN", "max": "MAX", "sum": "SUM", "avg": "AVG"}
 
 
-def _sql_literal(value: str) -> str:
+def _sql_literal(value: Optional[Any]) -> str:
     """Render an enumerated clause value as a single-quoted SQL string literal."""
+    if value is None:
+        return "NULL"
     return "'" + value.replace("'", "''") + "'"
+
+
+def _value_in_pair(value: Optional[Any], a_ref: str, b_ref: str) -> str:
+    """SQL predicate: the (possibly null) clause value is one of the two operand refs."""
+    if value is None:
+        return f"({a_ref} IS NULL OR {b_ref} IS NULL)"
+    return f"{_sql_literal(value)} IN ({a_ref}, {b_ref})"
 
 
 def _enumerated_case(rule: ViralPropagationRule, a_ref: str, b_ref: str) -> str:
@@ -35,20 +44,17 @@ def _enumerated_case(rule: ViralPropagationRule, a_ref: str, b_ref: str) -> str:
     When there are no WHEN clauses (e.g. an else-only rule), emits just the default
     scalar expression instead of the invalid ``CASE  ELSE ... END`` form.
     """
-    pair = f"({a_ref}, {b_ref})"
     whens: List[str] = []
     binary = [c for c in rule.enumerated_clauses if len(c["values"]) == 2]
     unary = [c for c in rule.enumerated_clauses if len(c["values"]) == 1]
     for clause in binary:
-        v1 = _sql_literal(clause["values"][0])
-        v2 = _sql_literal(clause["values"][1])
-        whens.append(
-            f"WHEN {v1} IN {pair} AND {v2} IN {pair} THEN {_sql_literal(clause['result'])}"
-        )
+        cond_a = _value_in_pair(clause["values"][0], a_ref, b_ref)
+        cond_b = _value_in_pair(clause["values"][1], a_ref, b_ref)
+        whens.append(f"WHEN {cond_a} AND {cond_b} THEN {_sql_literal(clause['result'])}")
     for clause in unary:
-        v1 = _sql_literal(clause["values"][0])
-        whens.append(f"WHEN {v1} IN {pair} THEN {_sql_literal(clause['result'])}")
-    default = _sql_literal(rule.default_value) if rule.default_value is not None else "NULL"
+        cond = _value_in_pair(clause["values"][0], a_ref, b_ref)
+        whens.append(f"WHEN {cond} THEN {_sql_literal(clause['result'])}")
+    default = _sql_literal(rule.default_value)
     if not whens:
         return default
     return "CASE " + " ".join(whens) + f" ELSE {default} END"

--- a/tests/ViralAttributes/test_viral_propagation.py
+++ b/tests/ViralAttributes/test_viral_propagation.py
@@ -174,6 +174,27 @@ class TestViralPropagationEndToEnd:
         # C+M→N (binary); M+F→M (unary "M"); X+Y→" " (else)
         assert list(result["DS_r"].data["VAt_1"]) == ["N", "M", " "]
 
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_null_condition_matches_null_value(self, use_duckdb: bool) -> None:
+        """A `when null` clause must match a null (pd.NA/None) viral value, not fall to else."""
+        result = run(
+            script=(
+                "define viral propagation ee (variable VAt_1) is\n"
+                '    when null then "Nullable";\n'
+                '    else "NO_COINCIDENCE"\n'
+                "end viral propagation;\n"
+                "DS_r <- DS_1 + DS_2;"
+            ),
+            data_structures=_ds_pair(DS_1VA),
+            datapoints={
+                "DS_1": pd.DataFrame({"Id_1": [1, 2], "Me_1": [10.0, 20.0], "VAt_1": ["X", None]}),
+                "DS_2": pd.DataFrame({"Id_1": [1, 2], "Me_1": [5.0, 15.0], "VAt_1": ["X", None]}),
+            },
+            use_duckdb=use_duckdb,
+        )
+        # X+X→else "NO_COINCIDENCE"; null+null→"Nullable" (when null)
+        assert list(result["DS_r"].data["VAt_1"]) == ["NO_COINCIDENCE", "Nullable"]
+
     def test_no_rule_gives_null(self) -> None:
         """Both operands viral but no rule defined → null."""
         result = run(


### PR DESCRIPTION
## Summary

Viral attr can now handle null conditions.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)
