### PR TITLE
Fix #829: ASTString transform identifier in None

### DIFF
--- a/src/vtlengine/AST/ASTString.py
+++ b/src/vtlengine/AST/ASTString.py
@@ -717,7 +717,10 @@ class ASTString(ASTTemplate):
         return f"{node.old_name} to {node.new_name}"
 
     def visit_TimeAggregation(self, node: AST.TimeAggregation) -> str:
-        period_to = _handle_literal(node.period_to)
+        if node.period_to_ref is not None:
+            period_to = self.visit(node.period_to_ref)
+        else:
+            period_to = _handle_literal(node.period_to)
         operand = "" if node.operand is None else f", {self.visit(node.operand)}"
 
         if node.period_from is None:

--- a/tests/AST/data/prettier/reference_time_agg_ref.vtl
+++ b/tests/AST/data/prettier/reference_time_agg_ref.vtl
@@ -1,0 +1,4 @@
+avr_m_1 <-
+	avg(
+		Day group all time_agg(sc_time)
+		);

--- a/tests/AST/data/prettier/time_agg_ref.vtl
+++ b/tests/AST/data/prettier/time_agg_ref.vtl
@@ -1,0 +1,1 @@
+avr_m_1 <- avg(Day group all time_agg(sc_time));

--- a/tests/AST/data/vtl/time_agg_ref.vtl
+++ b/tests/AST/data/vtl/time_agg_ref.vtl
@@ -1,0 +1,1 @@
+avr_m_1 <- avg(Day group all time_agg(sc_time));

--- a/tests/AST/test_AST_String.py
+++ b/tests/AST/test_AST_String.py
@@ -26,6 +26,7 @@ params = [
     "GH_358.vtl",
     "comments_end_line.vtl",
     "time_agg.vtl",
+    "time_agg_ref.vtl",
     "viral_propagation.vtl",
     "round_with_slash.vtl",
     "trunc_with_slash.vtl",
@@ -58,6 +59,7 @@ params_prettier = [
     ("validation_str_errorlevel.vtl", "reference_validation_str_errorlevel.vtl"),
     ("unbounded.vtl", "reference_unbounded.vtl"),
     ("time_agg.vtl", "reference_time_agg.vtl"),
+    ("time_agg_ref.vtl", "reference_time_agg_ref.vtl"),
     ("viral_propagation.vtl", "reference_viral_propagation.vtl"),
 ]
 


### PR DESCRIPTION
## Summary

ASTString now set the scalars correctly.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)
