### PR TITLE
Fix #834, #835 and #836: Fixed Analytic, time_agg, lead and lag ASTString errors

### DIFF
--- a/src/vtlengine/AST/ASTConstructorModules/Expr.py
+++ b/src/vtlengine/AST/ASTConstructorModules/Expr.py
@@ -1009,6 +1009,7 @@ class Expr:
         period_to = None
         period_to_ref = None
         period_from = None
+        period_from_optional = False
         optional_expr_node = None
         conf = None
         period_to_found = False
@@ -1022,7 +1023,7 @@ class Expr:
                     else:
                         period_from = str(child.text)[1:-1]
                 elif child.symbol_type == vtl_cpp_parser.OPTIONAL:
-                    pass  # periodIndFrom is OPTIONAL, skip
+                    period_from_optional = True
                 elif child.symbol_type in (vtl_cpp_parser.FIRST, vtl_cpp_parser.LAST):
                     conf = child.text
             elif child.rule_index == RC.VAR_ID[0] and not period_to_found:
@@ -1050,6 +1051,7 @@ class Expr:
             period_to=period_to,
             period_to_ref=period_to_ref,
             period_from=period_from,
+            period_from_optional=period_from_optional,
             conf=conf_val,
             **extract_token_info(ctx),
         )
@@ -1904,6 +1906,7 @@ class Expr:
             period_to = None
             period_to_ref = None
             period_from = None
+            period_from_optional = False
             operand_node = None
             conf = None
             period_to_found = False
@@ -1916,6 +1919,9 @@ class Expr:
                             period_to_found = True
                         else:
                             period_from = child.text[1:-1]
+                    elif child.symbol_type == vtl_cpp_parser.OPTIONAL:
+                        # periodIndFrom omitted via the explicit ``_`` placeholder
+                        period_from_optional = True
                     elif child.symbol_type in (vtl_cpp_parser.FIRST, vtl_cpp_parser.LAST):
                         conf = child.text
                 elif child.rule_index == RC.VAR_ID[0] and not period_to_found:
@@ -1935,6 +1941,7 @@ class Expr:
                     period_to=period_to,
                     period_to_ref=period_to_ref,
                     period_from=period_from,
+                    period_from_optional=period_from_optional,
                     conf=conf,
                     **extract_token_info(ctx),
                 )

--- a/src/vtlengine/AST/ASTConstructorModules/ExprComponents.py
+++ b/src/vtlengine/AST/ASTConstructorModules/ExprComponents.py
@@ -758,10 +758,11 @@ class ExprComp:
             period_ind_from_token = ctx_list[idx + 1]
             idx = idx + 2
 
-        if (
+        period_from_optional = (
             period_ind_from_token is not None
-            and period_ind_from_token.symbol_type != vtl_cpp_parser.OPTIONAL
-        ):
+            and period_ind_from_token.symbol_type == vtl_cpp_parser.OPTIONAL
+        )
+        if period_ind_from_token is not None and not period_from_optional:
             period_from = str(period_ind_from_token.text)[1:-1]
 
         # Find optionalExprComponent (op)
@@ -798,6 +799,7 @@ class ExprComp:
             period_to=period_to,
             period_to_ref=period_to_ref,
             period_from=period_from,
+            period_from_optional=period_from_optional,
             conf=conf,
             **extract_token_info(ctx),
         )

--- a/src/vtlengine/AST/ASTString.py
+++ b/src/vtlengine/AST/ASTString.py
@@ -723,10 +723,12 @@ class ASTString(ASTTemplate):
             period_to = _handle_literal(node.period_to)
         operand = "" if node.operand is None else f", {self.visit(node.operand)}"
 
-        if node.period_from is None:
-            period_from = ", _" if node.operand is not None else ""
-        else:
+        if node.period_from is not None:
             period_from = f", {_handle_literal(node.period_from)}"
+        elif node.period_from_optional:
+            period_from = ", _"
+        else:
+            period_from = ""
         config = "" if node.conf is None else f", {node.conf}"
         return f"{node.op}({period_to}{period_from}{operand}{config})"
 

--- a/src/vtlengine/AST/ASTString.py
+++ b/src/vtlengine/AST/ASTString.py
@@ -800,9 +800,14 @@ class ASTString(ASTTemplate):
             start = f"unbounded {node.start_mode}"
         elif node.start_mode == "current":
             start = "current data point"
+        elif isinstance(node.start, AST.AST):
+            start = f"{self.visit(node.start)} {node.start_mode}"
         else:
             start = f"{node.start if node.start != 'current row' else 0} {node.start_mode}"
-        stop = f"{node.stop if node.stop != 'current row' else 0} {node.stop_mode}"
+        if isinstance(node.stop, AST.AST):
+            stop = f"{self.visit(node.stop)} {node.stop_mode}"
+        else:
+            stop = f"{node.stop if node.stop != 'current row' else 0} {node.stop_mode}"
         if node.stop_mode == "current":
             stop = "current data point"
         mode = "data points" if node.type_ == "data" else "range"

--- a/src/vtlengine/AST/ASTString.py
+++ b/src/vtlengine/AST/ASTString.py
@@ -581,7 +581,10 @@ class ASTString(ASTTemplate):
         window = f" {self.visit(node.window)}" if node.window is not None else ""
         params = ""
         if node.params:
-            params = "" if len(node.params) == 0 else f", {int(node.params[0])}"
+            rendered_params = [
+                self.visit(p) if isinstance(p, AST.AST) else str(p) for p in node.params
+            ]
+            params = ", " + ", ".join(rendered_params)
         if self.pretty:
             result = (
                 f"{node.op}({nl}{tab * 3}{operand}{params} over({partition}{order} {window})"

--- a/src/vtlengine/AST/__init__.py
+++ b/src/vtlengine/AST/__init__.py
@@ -467,6 +467,7 @@ class TimeAggregation(AST):
     period_to: Optional[str] = None
     period_to_ref: Optional[AST] = None  # VarID, mutually exclusive with period_to
     period_from: Optional[str] = None
+    period_from_optional: bool = False
     operand: Optional[AST] = None
     conf: Optional[str] = None
 

--- a/tests/AST/data/vtl/lag_lead_offset.vtl
+++ b/tests/AST/data/vtl/lag_lead_offset.vtl
@@ -1,0 +1,5 @@
+DS_r1 := lag ( ds_1 , sc1 over ( partition by Id_1 , Id_2 order by Id_3 ) );
+DS_r2 := lead ( ds_1 , sc1 over ( partition by Id_1 , Id_2 order by Id_3 ) );
+DS_r3 := lag ( ds_1 , 2 over ( partition by Id_1 order by Id_3 ) );
+DS_r4 := lag ( ds_1 , 2, 0 over ( partition by Id_1 order by Id_3 ) );
+DS_r5 := lead ( ds_1 , 1, "x" over ( partition by Id_1 order by Id_3 ) );

--- a/tests/AST/data/vtl/time_agg_optional.vtl
+++ b/tests/AST/data/vtl/time_agg_optional.vtl
@@ -1,0 +1,4 @@
+DS_r1 := time_agg(DS_1, a);
+DS_r2 := sum ( DS_1 group all time_agg ( "A" ) );
+DS_r3 := time_agg ( "Q", cast ( "2012M01", time_period, "YYYY\MMM" ) );
+DS_r4 := time_agg ( "A", _, cast ( "2012M1", date, "YYYYMMDD" ), first );

--- a/tests/AST/data/vtl/windowing_scalar_bound.vtl
+++ b/tests/AST/data/vtl/windowing_scalar_bound.vtl
@@ -1,0 +1,4 @@
+DS_r1 := DS_1[calc me_win := sum(me over (partition by id order by anyo data points between sc1 preceding and 1 following))];
+DS_r2 := DS_1[calc me_win := sum(me over (partition by id order by anyo data points between 1 preceding and sc1 following))];
+DS_r3 := DS_1[calc me_win := sum(me over (partition by id order by anyo data points between 3 preceding and 1 following))];
+DS_r4 := DS_1[calc me_win := sum(me over (partition by id order by anyo data points between unbounded preceding and current data point))];

--- a/tests/AST/test_AST_String.py
+++ b/tests/AST/test_AST_String.py
@@ -27,6 +27,7 @@ params = [
     "comments_end_line.vtl",
     "time_agg.vtl",
     "time_agg_ref.vtl",
+    "time_agg_optional.vtl",
     "viral_propagation.vtl",
     "round_with_slash.vtl",
     "trunc_with_slash.vtl",

--- a/tests/AST/test_AST_String.py
+++ b/tests/AST/test_AST_String.py
@@ -28,6 +28,7 @@ params = [
     "time_agg.vtl",
     "time_agg_ref.vtl",
     "time_agg_optional.vtl",
+    "lag_lead_offset.vtl",
     "viral_propagation.vtl",
     "round_with_slash.vtl",
     "trunc_with_slash.vtl",

--- a/tests/AST/test_AST_String.py
+++ b/tests/AST/test_AST_String.py
@@ -29,6 +29,7 @@ params = [
     "time_agg_ref.vtl",
     "time_agg_optional.vtl",
     "lag_lead_offset.vtl",
+    "windowing_scalar_bound.vtl",
     "viral_propagation.vtl",
     "round_with_slash.vtl",
     "trunc_with_slash.vtl",


### PR DESCRIPTION
## Summary

- Fixed optional handling in time_agg ASTString
- Fixed param handling in Analytic ASTString
- Fixed AST object printing in Analytic window ASTString

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)
