### PR TITLE
Fix #851: Semantic time_agg error with scalars

### DIFF
--- a/src/vtlengine/Operators/Time.py
+++ b/src/vtlengine/Operators/Time.py
@@ -732,7 +732,7 @@ class Time_Aggregation(Time):
 
     @classmethod
     def _check_duration(cls, value: str) -> None:
-        if value not in PERIOD_IND_MAPPING:
+        if value is not None and value not in PERIOD_IND_MAPPING:
             raise SemanticError("1-1-19-3", op=cls.op, param="duration")
 
     @classmethod

--- a/src/vtlengine/Operators/Time.py
+++ b/src/vtlengine/Operators/Time.py
@@ -731,7 +731,7 @@ class Time_Aggregation(Time):
         return result
 
     @classmethod
-    def _check_duration(cls, value: str) -> None:
+    def _check_duration(cls, value: Optional[str]) -> None:
         if value is not None and value not in PERIOD_IND_MAPPING:
             raise SemanticError("1-1-19-3", op=cls.op, param="duration")
 


### PR DESCRIPTION
## Summary

Semantic time_agg raise an error with null value duration scalars.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)
