### PR TITLE
Pin numpy>=2.4.4 for Python >=3.11 so lock regenerations keep cp314 wheels

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2292,4 +2292,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "883306bcffd2a5ab1cb34970c404f5da3ca97d58a9e6fceef5d6970fc9dc74de"
+content-hash = "c915b5fb5fb58109f9ac6ae3942007ed23639661e894b97903f93035e943f387"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,12 @@ dependencies = [
     "pyarrow>=14.0,<25.0; python_version >= '3.10' and python_version < '3.14'",
     "pyarrow>=22.0,<25.0; python_version >= '3.14'",
     "numpy>=2.0.2,<2.1; python_version < '3.10'",
-    "numpy>=2.2.0,<2.5; python_version >= '3.10'",
+    # Split so no single numpy version covers the whole range: 2.2.x is the last
+    # series supporting 3.10 but ships no cp314 wheels, so pin >=3.11 to 2.4.x
+    # (which has them). This keeps Dependabot lock regenerations from collapsing
+    # numpy to 2.2.6 for all versions and breaking the Python 3.14 build.
+    "numpy>=2.2.0,<2.5; python_version == '3.10'",
+    "numpy>=2.4.4,<2.5; python_version >= '3.11'",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

A single numpy constraint (`numpy>=2.2.0,<2.5; python_version >= '3.10'`) let the resolver satisfy the entire Python range with numpy **2.2.6**, which ships **no cp314 wheels** (it predates Python 3.14). Every Dependabot lock regeneration therefore collapsed numpy to 2.2.6 for *all* Python versions, and the `testing (windows-latest, 3.14)` job failed trying to build numpy from source (no wheel available).

This splits the marker so that no single numpy version can cover the whole range:

```
"numpy>=2.2.0,<2.5; python_version == '3.10'",   # last series supporting 3.10 (no cp314 wheels)
"numpy>=2.4.4,<2.5; python_version >= '3.11'",    # has cp314 wheels
```

Because 2.2.6 can't satisfy the `>=3.11` floor and 2.4.x can't install on 3.10, Poetry is forced to keep two entries — so a fresh `poetry lock` (including Dependabot's) always retains a 3.14-capable numpy. Mirrors the existing `pyarrow` split. Follows the same root cause fixed ad-hoc in #865.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`) — only `pyproject.toml`/`poetry.lock` touched
- [x] Lock is consistent with `pyproject.toml` (`poetry check --lock` → "All set!", Poetry 2.4.1)
- [x] Verified a from-scratch `poetry lock` keeps the split (2.2.6 for 3.10, 2.4.6 for >=3.11 with cp314 wheels)
- [ ] CI green (running on this PR)

## Impact / Risk

- **Behavior:** None for 3.11–3.13 (already resolved to 2.4.x in the lock); only makes the constraint explicit. Lock diff vs main is just the content-hash.
- **API/SDMX compatibility:** None.
- **Release/changelog:** Build/CI reliability fix — unblocks Python 3.14 on Windows for every future dependency bump.

## Notes

- Once merged, `@dependabot rebase` on the open lock-bump PRs is safe — their regenerated locks will keep the 3.14 numpy entry instead of dropping it.
- No linked issue yet; happy to open a tracking Bug and add a closing keyword for release-notes categorization if you'd like.
