### PR TITLE
ci: pin GitHub Actions to commit SHAs and bump to latest

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Create release with notes
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Check for documentation label
         id: check
-        uses: actions/github-script@v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const merged = context.payload.pull_request.merged;
@@ -100,25 +100,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.client_payload.tag_name || github.ref }}
           fetch-depth: 0
       - name: Set up host Python 3.13
         # pyodide-build requires the host interpreter's major.minor to match the
         # target Pyodide's Python; Pyodide 0.29.3 targets 3.13.
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
       - name: Cache vtlengine WebAssembly wheel
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: wasm-wheel-cache
         with:
           path: docs/jupyterlite/wheels
           key: vtl-wasm-wheel-${{ hashFiles('src/vtlengine/**', 'CMakeLists.txt', 'pyproject.toml', 'scripts/setup_antlr4_runtime.sh') }}
       - name: Cache Emscripten SDK
         if: steps.wasm-wheel-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: emsdk
           key: emsdk-4.0.9-${{ runner.os }}
@@ -134,7 +134,7 @@ jobs:
           export PATH="$PWD/.pyobuild/bin:$PATH"
           bash docs/jupyterlite/build-wheel.sh
       - name: Cache Pyodide distribution
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: docs/jupyterlite/.build
           key: pyodide-dist-0.29.3
@@ -147,7 +147,7 @@ jobs:
           export VTLENGINE_WHEEL="$(ls "$PWD"/docs/jupyterlite/wheels/vtlengine-*-pyodide_2025_0_wasm32.whl)"
           bash docs/jupyterlite/build.sh
       - name: Upload JupyterLite site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jupyterlite-site
           path: docs/jupyterlite/_output
@@ -166,25 +166,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.client_payload.tag_name || github.ref }}
           fetch-depth: 0  # Fetch all history for all tags and branches
       - name: Install poetry
         run: pipx install poetry
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
           cache: poetry
       - name: Cache ANTLR4 runtime prebuilt
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: antlr4-cache
         with:
           path: build/antlr4-prefix
           key: antlr4-runtime-${{ runner.os }}-py3.13-${{ hashFiles('scripts/setup_antlr4_runtime.sh', 'CMakeLists.txt') }}
       - name: Cache C++ parser wheel
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cpp-cache
         with:
           path: .cpp-wheel
@@ -249,7 +249,7 @@ jobs:
       - name: Upload the docs site
         # Pages is published by the deploy job (which also merges in the demo),
         # so the heavy wasm build runs in parallel with this docs build.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-site
           path: _site
@@ -266,22 +266,22 @@ jobs:
     needs: [ build, build-jupyterlite ]
     steps:
       - name: Download the docs site
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-site
           path: _site
       - name: Add the JupyterLite demo to the site (/jupyterlite)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true  # don't block the docs deploy if the demo build failed
         with:
           name: jupyterlite-site
           path: _site/jupyterlite
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,17 +28,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.client_payload.tag_name || github.ref }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@d16cc544083d96996f923fc4b318fee3cb14b34e # v3.4.1
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-${{ matrix.runner }}-${{ matrix.arch }}
           path: wheelhouse/*.whl
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,22 +24,22 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
       - name: Cache ANTLR4 runtime prebuilt
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: antlr4-cache
         with:
           path: build/antlr4-prefix
           key: antlr4-runtime-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('scripts/setup_antlr4_runtime.sh', 'CMakeLists.txt') }}
       - name: Cache compiled C++ parser
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cpp-cache
         with:
           # Just the compiled extension binary — restoring it puts it back

--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -17,17 +17,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Cache ANTLR4 runtime prebuilt
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: antlr4-cache
         with:
           path: build/antlr4-prefix
           key: antlr4-runtime-ubuntu2404-py3.12-${{ hashFiles('scripts/setup_antlr4_runtime.sh', 'CMakeLists.txt') }}
 
       - name: Cache compiled C++ parser
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cpp-cache
         with:
           # Just the compiled extension binary — restoring it puts it back

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Compare versions
         run: bash scripts/check_version.sh


### PR DESCRIPTION
## Summary

Pin every GitHub Actions reference in the CI workflows to a full 40-char commit SHA (with a `# vX.Y.Z` comment), matching the existing `release.yml` style, and bump each action to its latest release in the same pass.

Mutable tags (`actions/checkout@v6`, `actions/cache@v4`, …) can be silently re-pointed at malicious code — SHA pinning removes that supply-chain risk. All SHAs were resolved with `gh api repos/<repo>/commits/<tag>` and verified for SHA↔tag consistency.

### Version → SHA bumps

| Action | Old | New |
| --- | --- | --- |
| actions/checkout | v6 / v6.0.2 | **v7.0.0** |
| actions/cache | v4 | **v6.1.0** |
| actions/setup-python | v6 | v6.3.0 |
| actions/github-script | v8 | **v9.0.0** |
| actions/upload-artifact | v4 / v4.6.2 | **v7.0.1** |
| actions/download-artifact | v4 / v4.3.0 | **v8.0.1** |
| actions/configure-pages | v5 | **v6.0.0** |
| actions/upload-pages-artifact | v4 | **v5.0.0** |
| actions/deploy-pages | v4 | **v5.0.0** |
| pypa/cibuildwheel | v3.4.1 | **v4.1.0** |
| pypa/gh-action-pypi-publish | v1.14.0 | v1.14.0 (already latest SHA) |

31 `uses:` lines updated across 6 workflow files; only the `@ref` changed (no logic/input edits).

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`) — N/A, no Python source changed
- [x] Tests pass (`pytest`) — validated by PR CI (`testing.yml` / `ubuntu_test_24_04.yml`)
- [x] Documentation updated (if applicable) — N/A

## Impact / Risk

- **Breaking changes (API/behavior):** None for the library. CI-only. `github-script` v9 drops `require('@actions/github')` and `getOctokit` redeclaration — both inline scripts were inspected and use only `github.rest.*` / `github.graphql()` / `context` / `core` / Node built-ins, so they are safe.
- **cibuildwheel v3→v4 (release wheels):** Accepts v4's new default — `delvewheel` now repairs **Windows** wheels (v3 did none), so the published Windows wheels change vs. today (Linux `auditwheel` / macOS `delocate` were already v3 defaults). v4 drops py3.8 (project builds cp39–cp314) and GraalPy (unused), both fine. ⚠️ This runs only in `release.yml` and **cannot be dry-run** (a `workflow_dispatch` would publish to PyPI), so it is validated on the next real release.
- **download-artifact v8:** `digest-mismatch` now defaults to `error` (was `warn`) — a safer default; only fires on actual corruption.
- **Validation coverage:** PR CI (`testing.yml`, `ubuntu_test_24_04.yml`, `version.yml`) exercises **checkout v7 / cache v6 / setup-python v6.3**. The `docs.yml`, `create-release.yml`, and `release.yml` bumps are **not** run by opening this PR — they run at docs-deploy / release time.

## Notes

SHAs verified via `gh api repos/<action>/commits/<tag>`. Labeled `workflows` (CI-only change; also keeps this out of the auto-generated release notes).
