### PR TITLE
Fix #879: strict, cross-backend-consistent Date/datetime validation

### DIFF
--- a/docs/data_types.rst
+++ b/docs/data_types.rst
@@ -145,6 +145,11 @@ Date
       - ISO 8601 date: ``"2020-01-15"``,
         ``"2020-01-15 10:30:00"``,
         ``"2020-01-15T10:30:00"``.
+        A time component, when present, must be a
+        complete ``HH:MM:SS`` (``T`` or space
+        separator). An optional timezone suffix
+        (``Z`` or ``±HH:MM``) is accepted; the offset
+        is discarded and the wall-clock time is kept.
         Nanosecond precision is truncated to
         microseconds. Year range: 1800–9999.
     * - **Input (DataFrame)**
@@ -157,6 +162,7 @@ Date
     * - **Output format**
       - ISO 8601 with ``T`` separator:
         ``"YYYY-MM-DD"`` or ``"YYYY-MM-DDThh:mm:ss"``.
+        Timezone offsets are not included in the output.
     * - **Output dtype**
       - ``string[pyarrow]``
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtlengine"
-version = "1.9.0"
+version = "1.9.1rc1"
 description = "Run and Validate VTL Scripts"
 license = "AGPL-3.0"
 readme = "README.md"

--- a/src/vtlengine/DataTypes/TimeHandling.py
+++ b/src/vtlengine/DataTypes/TimeHandling.py
@@ -598,12 +598,15 @@ def check_max_date(str_: Optional[str]) -> Optional[str]:
     if len(str_) == 9 and str_[7] == "-":
         str_ = str_[:-1] + "0" + str_[-1]
 
-    # Accept YYYY-MM-DD (len 10) or YYYY-MM-DD[T| ]HH:MM:SS[.fffffffff]
-    has_time = len(str_) > 10 and str_[10] in ("T", " ")
-    if has_time:
-        from vtlengine.DataTypes._time_checking import _truncate_nanoseconds
+    # Accept YYYY-MM-DD (len 10) or a full YYYY-MM-DD[T| ]HH:MM:SS[.ffffff][+HH:MM|Z].
+    # A time component, when present, must be a COMPLETE HH:MM:SS.
+    from vtlengine.DataTypes._time_checking import _has_time_component, normalize_datetime
 
-        return dt.fromisoformat(_truncate_nanoseconds(str_)).isoformat(sep=" ")
+    if _has_time_component(str_):
+        try:
+            return normalize_datetime(str_)
+        except ValueError:
+            raise RunTimeError("2-1-19-8", date=str_) from None
     elif len(str_) == 10 and str_[7] == "-":
         return date.fromisoformat(str_).isoformat()
     else:

--- a/src/vtlengine/DataTypes/_time_checking.py
+++ b/src/vtlengine/DataTypes/_time_checking.py
@@ -29,45 +29,83 @@ def _truncate_nanoseconds(value: str) -> str:
     return value
 
 
+# A full date followed by a COMPLETE HH:MM:SS time. Hours, minutes AND seconds
+# are required when a time component is present; fractional seconds and an optional
+# timezone (+HH:MM, -HH:MM or Z) are allowed. Partial times ("HH" / "HH:MM") are
+# rejected here; value ranges (hour <= 23, real calendar day) are validated
+# afterwards by datetime.fromisoformat.
+_STRICT_DATETIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:\d{2}|Z)?$"
+)
+
+
+def normalize_datetime(value: str) -> str:
+    """Validate a datetime string carrying a time component and normalize it.
+
+    Requires a full ``YYYY-MM-DD[T| ]HH:MM:SS`` value (hours, minutes and seconds);
+    fractional seconds and a timezone suffix are accepted. Sub-second precision beyond
+    microseconds is truncated. Output uses a single space separator. Raises
+    ``ValueError`` if the time component is missing, truncated, malformed or out of range.
+    """
+    if _STRICT_DATETIME_RE.match(value) is None:
+        raise ValueError(f"Invalid or incomplete time component in {value!r}")
+    return datetime.fromisoformat(_truncate_nanoseconds(value)).isoformat(sep=" ")
+
+
 def parse_date_value(value: str) -> date:
     """Parse a date or datetime string into a date object (time part is discarded)."""
     return date.fromisoformat(value[:10])
 
 
-def check_date(value: str) -> str:
+def _build_date_error(value: str) -> InputValidationException:
+    """Build a precise error for a value that failed date parsing.
+
+    Distinguishes an unusable format, a month outside 1..12, a real-but-out-of-range
+    calendar day (e.g. 2020-02-31), and a valid date part carrying an invalid or
+    incomplete time (e.g. 2020-01-01T25:00:00, 2020-01-01T12:30, 2020-01-01X12:30:45).
     """
-    Check if the date is in the correct format.
-    Accepts YYYY-MM-DD and YYYY-MM-DD[T| ]HH:MM:SS[.fffffffff] (ISO 8601).
-    Output always uses T separator for datetime values, no timezone.
-    Nanosecond input is truncated to microsecond precision.
+    date_part_match = _DATE_PART_RE.match(value)
+    if not date_part_match:
+        return InputValidationException(
+            f"Date {value} is not in the correct format. Use YYYY-MM-DD or YYYY-MM-DD HH:MM:SS."
+        )
+    month = int(date_part_match.group("month"))
+    if not 1 <= month <= 12:
+        return InputValidationException(f"Date {value} is invalid. Month must be between 1 and 12.")
+    try:
+        date.fromisoformat(value[:10])
+    except ValueError:
+        return InputValidationException(f"Date {value} is out of range for the month.")
+    return InputValidationException(
+        f"Date {value} has an invalid or incomplete time; expected YYYY-MM-DD HH:MM:SS."
+    )
+
+
+def check_date(value: str) -> str:
+    """Check a date is in the correct format.
+
+    Accepts ``YYYY-MM-DD`` and ``YYYY-MM-DD[T| ]HH:MM:SS[.ffffff][+HH:MM|Z]`` (ISO 8601).
+    A time component, when present, must be a COMPLETE ``HH:MM:SS``; partial times such
+    as ``HH`` or ``HH:MM`` are rejected. Datetime output uses a single space separator;
+    nanosecond input is truncated to microsecond precision.
     """
     value = value.strip()
     has_time = _has_time_component(value)
     try:
         if has_time:
-            iso_result = datetime.fromisoformat(_truncate_nanoseconds(value)).isoformat(sep=" ")
+            iso_result = normalize_datetime(value)
         else:
             if len(value) == 9 and value[7] == "-":
                 value = value[:-1] + "0" + value[-1]
             iso_result = date.fromisoformat(value).isoformat()
     except ValueError:
-        date_part_match = _DATE_PART_RE.match(value)
-        if date_part_match:
-            month = int(date_part_match.group("month"))
-            if not 1 <= month <= 12:
-                raise InputValidationException(
-                    f"Date {value} is invalid. Month must be between 1 and 12."
-                )
-            raise InputValidationException(f"Date {value} is out of range for the month.")
-        raise InputValidationException(
-            f"Date {value} is not in the correct format. Use YYYY-MM-DD or YYYY-MM-DD HH:MM:SS."
-        )
+        raise _build_date_error(value) from None
 
     # Check date is between 1800 and 9999
     year = int(value[:4])
     if not 1800 <= year <= 9999:
         raise InputValidationException(
-            f"Date {value} is invalid. Year must be between 1900 and 9999."
+            f"Date {value} is invalid. Year must be between 1800 and 9999."
         )
 
     return iso_result

--- a/src/vtlengine/DataTypes/_time_checking.py
+++ b/src/vtlengine/DataTypes/_time_checking.py
@@ -43,13 +43,20 @@ def normalize_datetime(value: str) -> str:
     """Validate a datetime string carrying a time component and normalize it.
 
     Requires a full ``YYYY-MM-DD[T| ]HH:MM:SS`` value (hours, minutes and seconds);
-    fractional seconds and a timezone suffix are accepted. Sub-second precision beyond
-    microseconds is truncated. Output uses a single space separator. Raises
+    fractional seconds and a timezone suffix (``Z`` or ``+HH:MM``) are accepted.
+    Sub-second precision beyond microseconds is truncated. Any timezone offset is
+    discarded (the wall-clock time is kept) so the result is a naive datetime,
+    consistent across backends. Output uses a single space separator. Raises
     ``ValueError`` if the time component is missing, truncated, malformed or out of range.
     """
     if _STRICT_DATETIME_RE.match(value) is None:
         raise ValueError(f"Invalid or incomplete time component in {value!r}")
-    return datetime.fromisoformat(_truncate_nanoseconds(value)).isoformat(sep=" ")
+    normalized = _truncate_nanoseconds(value)
+    # datetime.fromisoformat only parses a trailing "Z" on Python 3.11+; rewrite it
+    # so 3.9/3.10 behave the same, then drop the offset (keep wall-clock -> naive).
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    return datetime.fromisoformat(normalized).replace(tzinfo=None).isoformat(sep=" ")
 
 
 def parse_date_value(value: str) -> date:

--- a/src/vtlengine/__init__.py
+++ b/src/vtlengine/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "validate_external_routine",
 ]
 
-__version__ = "1.9.0"
+__version__ = "1.9.1rc1"

--- a/src/vtlengine/duckdb_transpiler/io/_io.py
+++ b/src/vtlengine/duckdb_transpiler/io/_io.py
@@ -14,6 +14,7 @@ import pandas as pd
 
 from vtlengine.DataTypes import Date, Number, TimePeriod
 from vtlengine.duckdb_transpiler.io._validation import (
+    VALID_DATE_REGEX,
     build_create_table_sql,
     build_csv_column_types,
     build_select_columns,
@@ -587,10 +588,6 @@ def _build_dataframe_select_columns(
             # a bad separator ("2020-01-01X12:30:45") and out-of-range times
             # ("2020-01-01T25:00:00") here with a clear message, instead of letting the
             # cast silently truncate them or surface a cryptic out-of-range error.
-            valid_date_regex = (
-                r"^\d{4}-\d{1,2}-\d{1,2}"
-                r"([ T]([01]\d|2[0-3]):[0-5]\d:[0-5]\d(\.\d+)?([+-]\d{2}(:?\d{2})?|Z)?)?$"
-            )
             col_as_varchar = f'CAST("{comp_name}" AS VARCHAR)'
             err = (
                 f"'Date ' || {col_as_varchar} || "
@@ -598,7 +595,7 @@ def _build_dataframe_select_columns(
             )
             exprs.append(
                 f'CASE WHEN "{comp_name}" IS NOT NULL '
-                f"AND NOT regexp_matches({col_as_varchar}, '{valid_date_regex}') "
+                f"AND NOT regexp_matches({col_as_varchar}, '{VALID_DATE_REGEX}') "
                 f"THEN error({err}) "
                 f'ELSE CAST("{comp_name}" AS {target_type}) END AS "{comp_name}"'
             )

--- a/src/vtlengine/duckdb_transpiler/io/_io.py
+++ b/src/vtlengine/duckdb_transpiler/io/_io.py
@@ -580,6 +580,28 @@ def _build_dataframe_select_columns(
             exprs.append(f'CAST(NULL AS {target_type}) AS "{comp_name}"')
         elif comp.data_type == Number:
             exprs.append(f'CAST(CAST("{comp_name}" AS VARCHAR) AS {target_type}) AS "{comp_name}"')
+        elif comp.data_type == Date:
+            # Accept only a bare date, or a date with a COMPLETE, in-range time
+            # (HH:MM:SS, optional fractional seconds / timezone), matching the strict
+            # rule on the pandas path. This rejects partial times ("...HH" / "...HH:MM"),
+            # a bad separator ("2020-01-01X12:30:45") and out-of-range times
+            # ("2020-01-01T25:00:00") here with a clear message, instead of letting the
+            # cast silently truncate them or surface a cryptic out-of-range error.
+            valid_date_regex = (
+                r"^\d{4}-\d{1,2}-\d{1,2}"
+                r"([ T]([01]\d|2[0-3]):[0-5]\d:[0-5]\d(\.\d+)?([+-]\d{2}(:?\d{2})?|Z)?)?$"
+            )
+            col_as_varchar = f'CAST("{comp_name}" AS VARCHAR)'
+            err = (
+                f"'Date ' || {col_as_varchar} || "
+                f"' has an invalid or incomplete time; expected YYYY-MM-DD HH:MM:SS.'"
+            )
+            exprs.append(
+                f'CASE WHEN "{comp_name}" IS NOT NULL '
+                f"AND NOT regexp_matches({col_as_varchar}, '{valid_date_regex}') "
+                f"THEN error({err}) "
+                f'ELSE CAST("{comp_name}" AS {target_type}) END AS "{comp_name}"'
+            )
         else:
             exprs.append(f'CAST("{comp_name}" AS {target_type}) AS "{comp_name}"')
     return exprs

--- a/src/vtlengine/duckdb_transpiler/io/_validation.py
+++ b/src/vtlengine/duckdb_transpiler/io/_validation.py
@@ -57,6 +57,15 @@ TIME_INTERVAL_PATTERN = (
 
 DURATION_PATTERN = r"^(A|S|Q|M|W|D)$"  # Year, Semester, Quarter, Month, Week, Day
 
+# Canonical Date/datetime input format shared by the CSV and DataFrame loaders and
+# kept in sync with the pandas validator (_time_checking._STRICT_DATETIME_RE):
+# a bare date, or a date + (T|space) + complete HH:MM:SS + optional fractional seconds
+# + optional timezone (+HH:MM or Z). Month/day allow 1-2 digits (DuckDB casts them).
+VALID_DATE_REGEX = (
+    r"^\d{4}-\d{1,2}-\d{1,2}"
+    r"([ T]([01]\d|2[0-3]):[0-5]\d:[0-5]\d(\.\d+)?([+-]\d{2}:\d{2}|Z)?)?$"
+)
+
 
 # =============================================================================
 # Error Mapping
@@ -423,10 +432,11 @@ def build_select_columns(
                 )
             elif csv_type == "DOUBLE" and "DECIMAL" in table_type:
                 select_cols.append(f'CAST("{comp_name}" AS {table_type}) AS "{comp_name}"')
-            # Date columns: read as VARCHAR, validate format, cast to DATE or TIMESTAMP
+            # Date columns: read as VARCHAR, validate format, cast to DATE or TIMESTAMP.
+            # Accepts a bare date or a full datetime with the T or space separator and an
+            # optional timezone (+HH:MM or Z); the same set the pandas loader accepts.
             elif csv_type == "VARCHAR" and comp.data_type == Date:
-                # VTL accepts hyphen-separated dates: YYYY-M-D or YYYY-MM-DD HH:MM:SS[.f]
-                date_regex = r"^\d{4}-\d{1,2}-\d{1,2}( \d{2}:\d{2}:\d{2}(\.\d+)?)?$"
+                date_regex = VALID_DATE_REGEX
                 null_check = f'"{comp_name}" IS NOT NULL'
                 if comp.nullable:
                     null_check += f""" AND "{comp_name}" != ''"""

--- a/tests/DateTime/test_datetime.py
+++ b/tests/DateTime/test_datetime.py
@@ -36,9 +36,10 @@ check_date_valid_params = [
     pytest.param("2020-12-31T23:59:59", "2020-12-31 23:59:59", id="datetime_end_of_day"),
     pytest.param(
         "2020-01-15T10:30:00+02:00",
-        "2020-01-15 10:30:00+02:00",
+        "2020-01-15 10:30:00",
         id="datetime_timezone_offset",
     ),
+    pytest.param("2020-01-15T10:30:00Z", "2020-01-15 10:30:00", id="datetime_utc_z"),
     pytest.param(
         "2020-01-15T10:30:00.123456",
         "2020-01-15 10:30:00.123456",
@@ -81,9 +82,10 @@ check_max_date_valid_params = [
     ),
     pytest.param(
         "2020-01-15T10:30:00+02:00",
-        "2020-01-15 10:30:00+02:00",
+        "2020-01-15 10:30:00",
         id="datetime_timezone_offset",
     ),
+    pytest.param("2020-01-15T10:30:00Z", "2020-01-15 10:30:00", id="datetime_utc_z"),
 ]
 
 check_max_date_invalid_params = [

--- a/tests/DateTime/test_datetime.py
+++ b/tests/DateTime/test_datetime.py
@@ -34,7 +34,11 @@ check_date_valid_params = [
     pytest.param("2020-01-15 10:30:00", "2020-01-15 10:30:00", id="datetime_space_separator"),
     pytest.param("2020-01-15T00:00:00", "2020-01-15 00:00:00", id="datetime_midnight"),
     pytest.param("2020-12-31T23:59:59", "2020-12-31 23:59:59", id="datetime_end_of_day"),
-    pytest.param("2020-01-15T10:30", "2020-01-15 10:30:00", id="datetime_no_seconds_normalized"),
+    pytest.param(
+        "2020-01-15T10:30:00+02:00",
+        "2020-01-15 10:30:00+02:00",
+        id="datetime_timezone_offset",
+    ),
     pytest.param(
         "2020-01-15T10:30:00.123456",
         "2020-01-15 10:30:00.123456",
@@ -55,6 +59,10 @@ check_date_valid_params = [
 check_date_invalid_params = [
     pytest.param("2020-01-15T25:00:00", InputValidationException, id="invalid_datetime_bad_hour"),
     pytest.param("1799-12-31", InputValidationException, id="invalid_year_below_range"),
+    pytest.param("2020-01-01T12", InputValidationException, id="invalid_partial_hour_t"),
+    pytest.param("2020-01-01T12:30", InputValidationException, id="invalid_partial_no_sec_t"),
+    pytest.param("2020-01-01 12", InputValidationException, id="invalid_partial_hour_space"),
+    pytest.param("2020-01-01 12:30", InputValidationException, id="invalid_partial_no_sec_space"),
 ]
 
 check_max_date_valid_params = [
@@ -71,10 +79,19 @@ check_max_date_valid_params = [
         "2020-01-15 10:30:00.123456",
         id="datetime_nanoseconds_truncated",
     ),
+    pytest.param(
+        "2020-01-15T10:30:00+02:00",
+        "2020-01-15 10:30:00+02:00",
+        id="datetime_timezone_offset",
+    ),
 ]
 
 check_max_date_invalid_params = [
     pytest.param("2020/01/15", RunTimeError, id="invalid_format"),
+    pytest.param("2020-01-01T12", RunTimeError, id="invalid_partial_hour_t"),
+    pytest.param("2020-01-01T12:30", RunTimeError, id="invalid_partial_no_sec_t"),
+    pytest.param("2020-01-01 12", RunTimeError, id="invalid_partial_hour_space"),
+    pytest.param("2020-01-01 12:30", RunTimeError, id="invalid_partial_no_sec_space"),
 ]
 
 scalar_time_params = [
@@ -496,6 +513,30 @@ def test_check_date_valid(input_value, expected):
 def test_check_date_invalid(input_value, expected_exception):
     with pytest.raises(expected_exception):
         check_date(input_value)
+
+
+check_date_message_params = [
+    pytest.param("2020-01-01T25:00:00", "has an invalid or incomplete time", id="bad_hour"),
+    pytest.param("2020-01-01X12:30:45", "has an invalid or incomplete time", id="bad_separator"),
+    pytest.param("2020-01-01T12:30", "has an invalid or incomplete time", id="partial_no_seconds"),
+]
+
+
+@pytest.mark.parametrize("input_value, expected_substring", check_date_message_params)
+def test_check_date_invalid_message(input_value, expected_substring):
+    with pytest.raises(InputValidationException) as exc_info:
+        check_date(input_value)
+    message = str(exc_info.value.args[0])
+    assert expected_substring in message
+    assert "out of range for the month" not in message
+
+
+def test_check_date_year_range_message():
+    with pytest.raises(InputValidationException) as exc_info:
+        check_date("1799-12-31")
+    message = str(exc_info.value.args[0])
+    assert "1800" in message
+    assert "1900" not in message
 
 
 @pytest.mark.parametrize("input_value, expected", check_max_date_valid_params)

--- a/tests/duckdb_transpiler/test_efficient_io.py
+++ b/tests/duckdb_transpiler/test_efficient_io.py
@@ -483,3 +483,56 @@ class TestRegisterDataframesPartialTime:
             use_duckdb=True,
         )
         assert result["DS_A"].data["Me_1"].notna().all()
+
+
+class TestCsvLoadDateFormats:
+    """DuckDB CSV loader must accept the same Date formats as pandas (T, tz, Z)."""
+
+    _STRUCT = {
+        "datasets": [
+            {
+                "name": "DS_1",
+                "DataStructure": [
+                    {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+                    {"name": "Me_1", "type": "Date", "role": "Measure", "nullable": True},
+                ],
+            }
+        ]
+    }
+
+    def test_csv_accepts_t_separator_and_timezone(self, tmp_path):
+        from vtlengine.API import run
+
+        csv = tmp_path / "DS_1.csv"
+        csv.write_text(
+            "Id_1,Me_1\n"
+            "1,2020-01-01T12:30:45\n"
+            "2,2020-01-01T12:30:45+02:00\n"
+            "3,2020-01-01T12:30:45Z\n"
+        )
+        res = run(
+            script="DS_A <- DS_1;",
+            data_structures=self._STRUCT,
+            datapoints={"DS_1": str(csv)},
+            use_duckdb=True,
+        )
+        # All three normalize to the same naive datetime (offset dropped).
+        assert res["DS_A"].data["Me_1"].tolist() == [
+            "2020-01-01T12:30:45",
+            "2020-01-01T12:30:45",
+            "2020-01-01T12:30:45",
+        ]
+
+    def test_csv_rejects_partial_time(self, tmp_path):
+        from vtlengine.API import run
+        from vtlengine.Exceptions import DataLoadError
+
+        csv = tmp_path / "DS_1.csv"
+        csv.write_text("Id_1,Me_1\n1,2020-01-01T12:30\n")
+        with pytest.raises(DataLoadError):
+            run(
+                script="DS_A <- DS_1;",
+                data_structures=self._STRUCT,
+                datapoints={"DS_1": str(csv)},
+                use_duckdb=True,
+            )

--- a/tests/duckdb_transpiler/test_efficient_io.py
+++ b/tests/duckdb_transpiler/test_efficient_io.py
@@ -429,3 +429,57 @@ class TestExtractDatapointPathsSDMX:
 
         assert path_dict is None
         assert "DS_1" in df_dict
+
+
+class TestRegisterDataframesPartialTime:
+    """DuckDB DataFrame-register path must reject truncated time components."""
+
+    _STRUCT = {
+        "datasets": [
+            {
+                "name": "DS_1",
+                "DataStructure": [
+                    {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+                    {"name": "Me_1", "type": "Date", "role": "Measure", "nullable": True},
+                ],
+            }
+        ]
+    }
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "2020-01-01 12:30",  # partial: no seconds (space separator)
+            "2020-01-01T12:30",  # partial: no seconds (T separator)
+            "2020-01-01T12",  # partial: hour only
+            "2020-01-01X12:30:45",  # bad separator (must not be truncated to date)
+            "2020-01-01T25:00:00",  # time value out of range
+        ],
+    )
+    def test_rejects_invalid_datetime(self, value):
+        from vtlengine.API import run
+        from vtlengine.Exceptions import DataLoadError
+
+        df = pd.DataFrame({"Id_1": [1], "Me_1": [value]})
+        with pytest.raises(DataLoadError) as exc_info:
+            run(
+                script="DS_A <- DS_1;",
+                data_structures=self._STRUCT,
+                datapoints={"DS_1": df},
+                use_duckdb=True,
+            )
+        # The offending value must be named in the error, never "unknown".
+        assert "unknown" not in str(exc_info.value.args[0])
+
+    @pytest.mark.parametrize("value", ["2020-01-01T12:30:45", "2020-01-01 12:30:45", "2020-01-01"])
+    def test_accepts_full_or_date_only(self, value):
+        from vtlengine.API import run
+
+        df = pd.DataFrame({"Id_1": [1], "Me_1": [value]})
+        result = run(
+            script="DS_A <- DS_1;",
+            data_structures=self._STRUCT,
+            datapoints={"DS_1": df},
+            use_duckdb=True,
+        )
+        assert result["DS_A"].data["Me_1"].notna().all()


### PR DESCRIPTION
## Summary

Makes Date/datetime validation strict and **consistent across the pandas and DuckDB backends**, and documents the accepted input formats.

**1. Reject partial/truncated times (all paths).** A time component, when present, must be a complete `HH:MM:SS` (fractional seconds and a timezone suffix stay valid); date-only stays valid. Previously the engine delegated to Python's lenient `datetime.fromisoformat`, silently accepting `2020-01-01T12` / `2020-01-01T12:30` and zero-filling. Now enforced on the pandas load (`check_date`) and cast (`check_max_date`) paths via a shared `normalize_datetime()`, and on both DuckDB paths (CSV loader + DataFrame register).

**2. Accurate error messages.** A `_build_date_error()` classifier reports the real fault — incomplete/invalid time vs. out-of-range month/day vs. bad format — instead of always saying "out of range for the month"; the year-range message now says `1800`. On DuckDB, a bad separator (`2020-01-01X12:30:45`, previously silently truncated to `2020-01-01`) and out-of-range times (`2020-01-01T25:00:00`, previously `Date unknown is out of range for the month`) are now rejected with a clear message.

**3. Cross-backend format parity.** All three input paths (pandas, DuckDB CSV, DuckDB DataFrame) now accept the same set: `YYYY-MM-DD`, or `YYYY-MM-DD` + (`T` | space) + complete `HH:MM:SS` + optional `.ffffff` + optional timezone (`±HH:MM` | `Z`). The DuckDB CSV loader previously rejected the `T` separator and any timezone; both DuckDB builders now share one `VALID_DATE_REGEX`. Timezones are normalized identically on both backends — the offset is dropped, keeping wall-clock (naive) — so the same input yields the same output. A trailing `Z` is accepted on all supported Python versions (3.9+).

**4. Docs.** `docs/data_types.rst` now documents the `T` separator, the required complete `HH:MM:SS`, and the accepted `Z`/`±HH:MM` timezone suffix (offset discarded).

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — full suite green on both backends (DuckDB: 5349 passed; pandas: 4777 passed)
- [x] Documentation updated (`docs/data_types.rst`)

## Impact / Risk

- **Behavior change:** partial/truncated times are rejected instead of silently zero-filled; malformed datetimes raise clearer, accurate errors; timezone offsets are now dropped (naive) on the pandas path too (previously preserved), making both backends consistent.
- Full datetimes (with `T`/space, fractional seconds, `±HH:MM`/`Z`) and date-only values remain valid. No CSV/JSON fixture had a `T`/tz value in a `Date` column, so no reference data changed.
- No public API/signature changes; no SDMX compatibility concerns.
- Release note: stricter and cross-backend-consistent Date/datetime parsing; clearer validation messages; timezone offsets are normalized away.

## Notes

- Pre-existing, still out of scope (neither involves `T`/`Z`): pandas requires zero-padded `\d{2}` month/day while DuckDB accepts `\d{1,2}` (`2020-1-1`); DuckDB promotes a date-only value to `...T00:00:00` when it shares a column with datetimes (pandas keeps it date-only).

Fixes #879