### PR TITLE
Align Python floor declarations to 3.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for your interest in contributing! This guide covers the basics to get you productive quickly.
 
 ## Getting Started
-- Use Python 3.9+.
+- Use Python 3.10+.
 - Install dependencies with poetry:
   ```bash
   poetry install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the [VTL Language 2.1](https://sdmx-twg.github.io/vtl/2.1/html/index.html).
 
 ### Requirements
 
-The VTL Engine requires Python 3.9 or higher.
+The VTL Engine requires Python 3.10 or higher.
 
 ### Install with pip
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2399,4 +2399,4 @@ test = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "16cc603ae77e4ed710171a747fb016623b6517f1951af5857757754952a06224"
+content-hash = "cf6b8ed25be03528affcac78d0eab090a16a3194539edaf7462be0481252f9d7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ docs = [
 
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 100
 lint.mccabe.max-complexity = 20
 lint.select = [
@@ -140,7 +140,7 @@ wheel.exclude = [
 ]
 
 [tool.cibuildwheel]
-build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 # Skip musllinux: duckdb 1.4.x ships no musllinux wheels, so vtlengine cannot resolve deps there.
 skip = "*-musllinux*"
 test-requires = ["pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.0.0rc3"
 description = "Run and Validate VTL Scripts"
 license = "AGPL-3.0"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "MeaningfulData", email = "info@meaningfuldata.eu"},
 ]
@@ -20,7 +20,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -39,10 +38,8 @@ dependencies = [
     "sqlglot>=22.2.0,<23.0",
     "pandas>=2.1.4,<3.0",
     "networkx>=2.8,<3.0",
-    "pyarrow>=14.0,<20.0; python_version < '3.10'",
-    "pyarrow>=14.0,<25.0; python_version >= '3.10' and python_version < '3.14'",
+    "pyarrow>=14.0,<25.0; python_version < '3.14'",
     "pyarrow>=22.0,<25.0; python_version >= '3.14'",
-    "numpy>=2.0.2,<2.1; python_version < '3.10'",
     # Split so no single numpy version covers the whole range: 2.2.x is the last
     # series supporting 3.10 but ships no cp314 wheels, so pin >=3.11 to 2.4.x
     # (which has them). This keeps Dependabot lock regenerations from collapsing
@@ -70,8 +67,7 @@ dev = [
     "pytest-xdist>=3.8.0,<4.0",
     "mypy>=1.18,<2.0",
     "pyarrow-stubs>=14.0,<25.0",
-    "pandas-stubs>2.1.4.231227,<2.2.3.240901; python_version < '3.10'",
-    "pandas-stubs>=2.2.3.241009,<3.0.0.260204; python_version >= '3.10'",
+    "pandas-stubs>=2.2.3.241009,<3.0.0.260204",
     "ruff>=0.15.12,<1.0.0",
     "types-jsonschema>=4.25.1,<5.0",
 ]

--- a/src/vtlengine/AST/DAG/__init__.py
+++ b/src/vtlengine/AST/DAG/__init__.py
@@ -362,7 +362,7 @@ class DAGAnalyzer(ASTTemplate):
             super().visit_UDOCall(node)
         else:
             node_sig = [type(p.type_) for p in node_args.parameters]
-            for sig, param in zip(node_sig, node.params):
+            for sig, param in zip(node_sig, node.params, strict=False):
                 if not isinstance(param, Constant) and sig is not Component:
                     self.visit(param)
 

--- a/src/vtlengine/Operators/String.py
+++ b/src/vtlengine/Operators/String.py
@@ -241,7 +241,7 @@ class Hamming(StringDistance):
     def py_op(s1: str, s2: str) -> int:
         if len(s1) != len(s2):
             raise SemanticError("1-1-18-11", op=STRING_DISTANCE, len1=len(s1), len2=len(s2))
-        return sum(1 for a, b in zip(s1, s2) if a != b)
+        return sum(1 for a, b in zip(s1, s2, strict=False) if a != b)
 
 
 class JaroWinkler(StringDistance):

--- a/src/vtlengine/Operators/__init__.py
+++ b/src/vtlengine/Operators/__init__.py
@@ -134,7 +134,7 @@ class Binary(Operator):
             )
         elif len(left_measures) == 0:
             raise SemanticError("1-1-1-8", op=cls.op, name=left_operand.name)
-        for left_measure, right_measure in zip(left_measures, right_measures):
+        for left_measure, right_measure in zip(left_measures, right_measures, strict=False):
             cls.type_validation(left_measure.data_type, right_measure.data_type)
 
         # We do not need anymore these variables

--- a/src/vtlengine/duckdb_transpiler/io/_execution.py
+++ b/src/vtlengine/duckdb_transpiler/io/_execution.py
@@ -258,7 +258,7 @@ def _build_dataset_fetch_select(
         )
         row = conn.execute(f"SELECT {exists_clauses}").fetchone()
         if row is not None:
-            has_time_cols = dict(zip(timestamp_cols, row))
+            has_time_cols = dict(zip(timestamp_cols, row, strict=False))
 
     exprs = []
     for col in ordered_cols:

--- a/tests/Concurrency/test_thread_safety.py
+++ b/tests/Concurrency/test_thread_safety.py
@@ -60,7 +60,7 @@ class TestConcurrentAggregation:
         for r in results:
             df = r["DS_r"].data
             assert len(df) == 3
-            sums = dict(zip(df["Id_1"], df["Me_1"]))
+            sums = dict(zip(df["Id_1"], df["Me_1"], strict=False))
             assert sums == {1: 30.0, 2: 70.0, 3: 50.0}
 
 
@@ -89,5 +89,5 @@ class TestConcurrentEval:
         for r in results:
             df = r["DS_r"].data
             assert len(df) == 5
-            doubled = dict(zip(df["Id_2"], df["Me_1"]))
+            doubled = dict(zip(df["Id_2"], df["Me_1"], strict=False))
             assert doubled["A"] in {20.0, 60.0, 100.0}

--- a/tests/duckdb_transpiler/test_run.py
+++ b/tests/duckdb_transpiler/test_run.py
@@ -800,7 +800,7 @@ class TestUnaryOperations:
         # Get the measure column (may be renamed by VTL semantic analysis based on result type)
         measure_col = [c for c in result_df.columns if c != "Id_1"][0]
         result_values = list(result_df[measure_col])
-        for rv, ev in zip(result_values, expected_values):
+        for rv, ev in zip(result_values, expected_values, strict=False):
             assert rv == ev, f"Expected {ev}, got {rv}"
 
 
@@ -844,7 +844,7 @@ class TestParameterizedOperations:
         results = execute_vtl_with_duckdb(vtl_script, data_structures, {"DS_1": input_df})
 
         result_values = list(results["DS_r"].sort_values("Id_1")["Me_1"])
-        for rv, ev in zip(result_values, expected_values):
+        for rv, ev in zip(result_values, expected_values, strict=False):
             assert rv == ev, f"Expected {ev}, got {rv}"
 
 
@@ -907,7 +907,7 @@ class TestTimeOperators:
         extracted_col = [c for c in result_df.columns if c.endswith("_val")][0]
         result_values = list(result_df[extracted_col])
 
-        for rv, ev in zip(result_values, expected_values):
+        for rv, ev in zip(result_values, expected_values, strict=False):
             assert rv == ev, f"Expected {ev}, got {rv}"
 
     # NOTE: Tests for flow_to_stock and stock_to_flow are deferred to
@@ -1051,7 +1051,7 @@ class TestComplexMultiOperatorStatements:
         # Should have A,1 and C,1
         assert len(result_df) == 2
         expected_ids = [("A", 1), ("C", 1)]
-        actual_ids = list(zip(result_df["Id_1"].tolist(), result_df["Id_2"].tolist()))
+        actual_ids = list(zip(result_df["Id_1"].tolist(), result_df["Id_2"].tolist(), strict=False))
         assert sorted(actual_ids) == sorted(expected_ids)
 
     def test_calc_with_arithmetic_and_functions(self, temp_data_dir):


### PR DESCRIPTION
## Summary

The project metadata declared `requires-python = ">=3.9"` while everything else already required 3.10: the Poetry constraint (`python = ">=3.10,<4.0"`), the CI test matrix (3.10–3.14) and the resolved lock file. Python 3.9 was therefore never actually supported — pip on 3.9 would accept the wheel and then fail against the locked dependencies. This aligns every declaration to **Python 3.10+**:

- `pyproject.toml`: `requires-python = ">=3.10"`, drop the `3.9` trove classifier, and remove the unreachable `python_version < '3.10'` dependency branches (pyarrow, numpy, pandas-stubs). The numpy 3.10 / 3.11+ marker split is untouched.
- `README.md` / `CONTRIBUTING.md`: state Python 3.10+.
- `[tool.ruff] target-version` moves to `py310`; the newly-activated B905 rule is satisfied by making the ten existing `zip()` call sites explicit with `strict=False` — exactly the previous implicit behavior, so the change stays behavior-neutral (tightening provably-safe sites to `strict=True` is left for a separate change).
- `[tool.cibuildwheel]` stops building `cp39-*` wheels: a cp39 wheel whose metadata says `Requires-Python >=3.10` cannot pass cibuildwheel's install-and-test step, so keeping it would break the wheels workflow.
- `poetry.lock`: content-hash regeneration only — the diff is a single line, with **no resolved version or marker changes** (Poetry already resolved for >=3.10).

The mismatch was noted in #891 (which remains open for the unrelated `fromisoformat` fractional-seconds bug).

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`) under the new `py310` target
- [x] Tests pass (`pytest` — 4974 passed, 11 skipped); `poetry check` passes and the lock diff is hash-only
- [x] Documentation updated (README / CONTRIBUTING)

## Impact / Risk

- Wheel metadata now advertises `Requires-Python: >=3.10`, so pip on Python 3.9 will refuse to install instead of failing later during dependency resolution — this is the honest behavior, not a support change.
- No dependency version changes; Dependabot-sensitive numpy marker split preserved verbatim.

## Notes

Release notes: packaging metadata now correctly states the minimum supported Python (3.10); 3.9 was already unsupported in practice.
