### PR TITLE
Fix #890: raise SemanticError on unpivot name collision with a viral attribute

### DIFF
--- a/src/vtlengine/Exceptions/messages.py
+++ b/src/vtlengine/Exceptions/messages.py
@@ -438,6 +438,12 @@ centralised_messages = {
         "message": "At op {op}: Not allowed to overwrite an Identifier: {comp_name}",
         "description": "Raised when an operation attempts to overwrite an existing Identifier.",
     },
+    "1-1-6-14": {
+        "message": "At op {op}: The component {name} in Dataset {dataset} could not be "
+        "included in the {op} op.",
+        "description": "Raised when a component cannot be included in the specified operation "
+        "because its name collides with a component already present in the result.",
+    },
     # Comparison errors
     "1-1-7-1": {
         "message": "At op {op}: Value in {left_name} of type {left_type} is not comparable "

--- a/src/vtlengine/Operators/Clause.py
+++ b/src/vtlengine/Operators/Clause.py
@@ -3,7 +3,7 @@ from copy import copy
 from typing import List, Type, Union
 
 from vtlengine.AST import RenameNode
-from vtlengine.AST.Grammar.tokens import AGGREGATE, CALC, DROP, KEEP, RENAME, SUBSPACE
+from vtlengine.AST.Grammar.tokens import AGGREGATE, CALC, DROP, KEEP, RENAME, SUBSPACE, UNPIVOT
 from vtlengine.DataTypes import (
     Boolean,
     ScalarType,
@@ -202,6 +202,8 @@ class Pivot(Operator):
 
 
 class Unpivot(Operator):
+    op = UNPIVOT
+
     @classmethod
     def validate(cls, operands: List[str], dataset: Dataset) -> Dataset:
         dataset_name = VirtualCounter._new_ds_name()
@@ -213,6 +215,11 @@ class Unpivot(Operator):
             raise SemanticError("1-2-10", op=cls.op)
         if identifier in dataset.components:
             raise SemanticError("1-1-6-2", op=cls.op, name=identifier, dataset=dataset_name)
+        retained_names = set(dataset.get_identifiers_names())
+        retained_names.update(dataset.get_viral_attributes_names())
+        retained_names.add(identifier)
+        if measure in retained_names:
+            raise SemanticError("1-1-6-14", op=cls.op, name=measure, dataset=dataset_name)
 
         result_components = {comp.name: comp for comp in dataset.get_identifiers()}
         result_dataset = Dataset(name=dataset_name, components=result_components, data=None)

--- a/tests/Semantic/data/DataStructure/input/CC_59-1.json
+++ b/tests/Semantic/data/DataStructure/input/CC_59-1.json
@@ -1,0 +1,33 @@
+{
+  "datasets": [
+    {
+      "name": "DS_1",
+      "DataStructure": [
+        {
+          "name": "Id_1",
+          "role": "Identifier",
+          "type": "Integer",
+          "nullable": false
+        },
+        {
+          "name": "Me_1",
+          "role": "Measure",
+          "type": "Number",
+          "nullable": true
+        },
+        {
+          "name": "Me_2",
+          "role": "Measure",
+          "type": "Number",
+          "nullable": true
+        },
+        {
+          "name": "VAt_1",
+          "role": "Viral Attribute",
+          "type": "String",
+          "nullable": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Semantic/data/vtl/CC_59.vtl
+++ b/tests/Semantic/data/vtl/CC_59.vtl
@@ -1,0 +1,1 @@
+DS_r := DS_1 [unpivot Id_2, VAt_1];

--- a/tests/Semantic/test_semantic.py
+++ b/tests/Semantic/test_semantic.py
@@ -1016,6 +1016,24 @@ class ClauseClauseTests(SemanticHelper):
 
         self.BaseTest(code=code, number_inputs=number_inputs, references_names=references_names)
 
+    def test_59(self):
+        """
+        Dataset --> Dataset
+        Status:
+        Expression: DS_r := DS_1 [unpivot Id_2, VAt_1];
+        Description: The unpivot measure name collides with a viral attribute name.
+
+        Git Branch: cr-890
+        Goal: The collision must raise a SemanticError, not a bare ValueError.
+        """
+        code = "CC_59"
+        number_inputs = 1
+        error_code = "1-1-6-14"
+
+        self.NewSemanticExceptionTest(
+            code=code, number_inputs=number_inputs, exception_code=error_code
+        )
+
 
 class MembershipTests(SemanticHelper):
     """


### PR DESCRIPTION
## Summary

`Unpivot.validate` validated the new identifier name but never the new measure name.
When the measure collided with a component retained in the result (a viral attribute,
a kept identifier, or the new identifier), `Dataset.add_component` raised a bare
`ValueError` that escaped the VTL error model — no code, no dataset context, not a
`SemanticError`.

This adds a collision check that raises the new `SemanticError` `1-1-6-14`, naming the
operator, the colliding component, and the output dataset. The measure may still reuse a
collapsed (removed) measure's name (`unpivot Id_2, Me_1`), which stays legal. Also set
`op = UNPIVOT` on the `Unpivot` class so the operator is named in this and the existing
`1-1-6-2` message (previously "At op None").

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable) — `error_messages.rst` is build-time generated; new code appears automatically

## Impact / Risk

- Breaking changes? A script that previously crashed with a bare `ValueError` now raises a catchable `SemanticError` — strictly an improvement; valid scripts are unaffected.
- Data/SDMX compatibility concerns? None.
- Notes for release/changelog? New error code `1-1-6-14`.

## Notes

New suite-pattern semantic test `CC_59` covers the collision. Full regression run: 1108 passed, 4 skipped.

Fixes #890

