### PR TITLE
Fix #891: normalize fractional seconds to microseconds before fromisoformat

### DIFF
--- a/src/vtlengine/DataTypes/_time_checking.py
+++ b/src/vtlengine/DataTypes/_time_checking.py
@@ -14,19 +14,26 @@ def _has_time_component(value: str) -> bool:
     return len(value) > 10 and value[10] in ("T", " ")
 
 
-def _truncate_nanoseconds(value: str) -> str:
-    """Truncate sub-second precision beyond 6 digits (microseconds) for Python compatibility."""
+def _normalize_fractional_seconds(value: str) -> str:
+    """Normalize sub-second precision to exactly 6 digits (microseconds).
+
+    ``_STRICT_DATETIME_RE`` accepts a fractional part of any length, but
+    ``datetime.fromisoformat`` before Python 3.11 only parses fractions of
+    exactly 3 or 6 digits. Padding short fractions and truncating long ones to 6
+    digits keeps the regex the single source of truth for what is accepted and
+    yields identical parsing on every supported interpreter (3.9+).
+    """
     dot_idx = value.find(".")
     if dot_idx == -1:
         return value
-    # Keep at most 6 decimal digits after the dot
+    # Span the run of digits forming the fractional part (a timezone suffix,
+    # if any, follows it and must be preserved).
     frac_end = dot_idx + 1
     while frac_end < len(value) and value[frac_end].isdigit():
         frac_end += 1
     frac_digits = value[dot_idx + 1 : frac_end]
-    if len(frac_digits) > 6:
-        return value[:dot_idx] + "." + frac_digits[:6] + value[frac_end:]
-    return value
+    normalized_frac = (frac_digits + "000000")[:6]
+    return value[:dot_idx] + "." + normalized_frac + value[frac_end:]
 
 
 # A full date followed by a COMPLETE HH:MM:SS time. Hours, minutes AND seconds
@@ -44,14 +51,16 @@ def normalize_datetime(value: str) -> str:
 
     Requires a full ``YYYY-MM-DD[T| ]HH:MM:SS`` value (hours, minutes and seconds);
     fractional seconds and a timezone suffix (``Z`` or ``+HH:MM``) are accepted.
-    Sub-second precision beyond microseconds is truncated. Any timezone offset is
-    discarded (the wall-clock time is kept) so the result is a naive datetime,
-    consistent across backends. Output uses a single space separator. Raises
-    ``ValueError`` if the time component is missing, truncated, malformed or out of range.
+    Sub-second precision is normalized to microseconds (padded or truncated to 6
+    digits) so ``datetime.fromisoformat`` parses it identically on every
+    supported interpreter. Any timezone offset is discarded (the wall-clock time
+    is kept) so the result is a naive datetime, consistent across backends.
+    Output uses a single space separator. Raises ``ValueError`` if the time
+    component is missing, truncated, malformed or out of range.
     """
     if _STRICT_DATETIME_RE.match(value) is None:
         raise ValueError(f"Invalid or incomplete time component in {value!r}")
-    normalized = _truncate_nanoseconds(value)
+    normalized = _normalize_fractional_seconds(value)
     # datetime.fromisoformat only parses a trailing "Z" on Python 3.11+; rewrite it
     # so 3.9/3.10 behave the same, then drop the offset (keep wall-clock -> naive).
     if normalized.endswith("Z"):
@@ -94,7 +103,7 @@ def check_date(value: str) -> str:
     Accepts ``YYYY-MM-DD`` and ``YYYY-MM-DD[T| ]HH:MM:SS[.ffffff][+HH:MM|Z]`` (ISO 8601).
     A time component, when present, must be a COMPLETE ``HH:MM:SS``; partial times such
     as ``HH`` or ``HH:MM`` are rejected. Datetime output uses a single space separator;
-    nanosecond input is truncated to microsecond precision.
+    fractional-second input is normalized to microsecond precision.
     """
     value = value.strip()
     has_time = _has_time_component(value)

--- a/tests/DateTime/test_datetime.py
+++ b/tests/DateTime/test_datetime.py
@@ -53,6 +53,36 @@ check_date_valid_params = [
         "2020-01-15 10:30:00.123456",
         id="datetime_nanoseconds_truncated",
     ),
+    pytest.param(
+        "2020-01-01 12:30:45.1",
+        "2020-01-01 12:30:45.100000",
+        id="datetime_fraction_1_digit",
+    ),
+    pytest.param(
+        "2020-01-01 12:30:45.12",
+        "2020-01-01 12:30:45.120000",
+        id="datetime_fraction_2_digits",
+    ),
+    pytest.param(
+        "2020-01-01T12:30:45.1234",
+        "2020-01-01 12:30:45.123400",
+        id="datetime_fraction_4_digits",
+    ),
+    pytest.param(
+        "2020-01-01T12:30:45.12345",
+        "2020-01-01 12:30:45.123450",
+        id="datetime_fraction_5_digits",
+    ),
+    pytest.param(
+        "2020-01-01T12:30:45.12Z",
+        "2020-01-01 12:30:45.120000",
+        id="datetime_fraction_2_digits_utc_z",
+    ),
+    pytest.param(
+        "2020-01-01T12:30:45.12+02:00",
+        "2020-01-01 12:30:45.120000",
+        id="datetime_fraction_2_digits_offset",
+    ),
 ]
 
 check_date_invalid_params = [
@@ -77,6 +107,16 @@ check_max_date_valid_params = [
         "2020-01-15T10:30:00.123456789",
         "2020-01-15 10:30:00.123456",
         id="datetime_nanoseconds_truncated",
+    ),
+    pytest.param(
+        "2020-01-15T10:30:00.12",
+        "2020-01-15 10:30:00.120000",
+        id="datetime_fraction_2_digits",
+    ),
+    pytest.param(
+        "2020-01-15T10:30:00.1234",
+        "2020-01-15 10:30:00.123400",
+        id="datetime_fraction_4_digits",
     ),
     pytest.param(
         "2020-01-15T10:30:00+02:00",


### PR DESCRIPTION
## Summary

The strict datetime validator (`DataTypes/_time_checking.py`) accepts fractional
seconds of any length via `_STRICT_DATETIME_RE`, then delegates parsing to
`datetime.fromisoformat`. Before Python 3.11, `fromisoformat` only parses
fractions of exactly 3 or 6 digits, so a value like `2020-01-01 12:30:45.12`
validated on 3.11+ but raised a date-format error on 3.9/3.10 — while the
regex-only DuckDB load path accepted it on every interpreter.

This replaces `_truncate_nanoseconds` (which only touched fractions longer than
6 digits) with `_normalize_fractional_seconds`, which pads short fractions and
truncates long ones to exactly 6 digits before `fromisoformat`. The regex stays
the single source of truth for what is accepted, and parsing is now identical on
every supported interpreter (3.9+) and input path.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — 5045 passed, 11 skipped
- [ ] Documentation updated (if applicable) — not applicable

## Impact / Risk

- Breaking changes? No. Short fractions are now padded (e.g. `.12` → `.120000`);
  values already handled (6+ digits, no fraction, `Z`/`+HH:MM` suffixes) are
  unchanged.
- Data/SDMX compatibility concerns? None — this aligns the strict validator with
  the regex-only path, removing a Python-version-dependent discrepancy.
- Notes for release/changelog? Fixes date values with 1–2 (and 4–5) fractional-
  second digits failing on Python 3.9/3.10.

## Notes

- Added regression tests in `tests/DateTime/test_datetime.py` for 1/2/4/5-digit
  fractions, plus `Z` and `+02:00` variants, covering both `check_date` and
  `check_max_date`.
- Only Python 3.12 is available in the dev env, so the 3.9/3.10 failure can't be
  triggered directly here; the fix is version-agnostic since `fromisoformat`
  only ever receives a 6-digit (or no) fraction after normalization.

Fixes #891

