### PR TITLE
Fix #901: serialize C++ parser access to prevent parse-tree use-after-free

### DIFF
--- a/src/vtlengine/API/__init__.py
+++ b/src/vtlengine/API/__init__.py
@@ -24,7 +24,7 @@ from vtlengine.AST import Start
 from vtlengine.AST.ASTConstructor import ASTVisitor
 from vtlengine.AST.ASTString import ASTString
 from vtlengine.AST.DAG import DAGAnalyzer
-from vtlengine.AST.Grammar._cpp_parser import vtl_cpp_parser
+from vtlengine.AST.Grammar._cpp_parser import parser_lock, vtl_cpp_parser
 from vtlengine.duckdb_transpiler.Config.config import configured_connection
 from vtlengine.duckdb_transpiler.io import execute_queries, extract_datapoint_paths
 from vtlengine.duckdb_transpiler.Transpiler import SQLTranspiler
@@ -87,18 +87,22 @@ def create_ast(text: str) -> Start:
         Exception: When the vtl syntax expression is wrong.
     """
     text = text + "\n"
-    cst = vtl_cpp_parser.parse(text)
-    error = vtl_cpp_parser.get_syntax_error()
-    if error is not None:
-        raise VTLSyntaxError(
-            line=error["line"],
-            column=error["column"] + 1,
-            detail=error["message"],
-            source_line=error["source_line"],
-            underline_length=error["underline_length"],
-        )
-    visitor = ASTVisitor()
-    ast = visitor.visitStart(cst)
+    # The C++ parser holds the parse tree in process-global state and hands Python
+    # raw pointers into it, so parse() and the lazy tree traversal in visitStart()
+    # must run under parser_lock to stay safe across threads (see parser_lock docs).
+    with parser_lock:
+        cst = vtl_cpp_parser.parse(text)
+        error = vtl_cpp_parser.get_syntax_error()
+        if error is not None:
+            raise VTLSyntaxError(
+                line=error["line"],
+                column=error["column"] + 1,
+                detail=error["message"],
+                source_line=error["source_line"],
+                underline_length=error["underline_length"],
+            )
+        visitor = ASTVisitor()
+        ast = visitor.visitStart(cst)
     DAGAnalyzer.create_dag(ast)
     return ast
 

--- a/src/vtlengine/AST/ASTComment.py
+++ b/src/vtlengine/AST/ASTComment.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 from vtlengine.API import create_ast
 from vtlengine.AST import Comment, Start
-from vtlengine.AST.Grammar._cpp_parser import vtl_cpp_parser
+from vtlengine.AST.Grammar._cpp_parser import parser_lock, vtl_cpp_parser
 
 
 def generate_ast_comment(comment: Dict[str, Any]) -> Comment:
@@ -46,23 +46,24 @@ def create_ast_with_comments(text: str) -> Start:
     Returns:
         AST: The generated AST with comments.
     """
-    # Parse with C++ parser (this also collects comments)
     text_with_newline = text + "\n"
-    vtl_cpp_parser.parse(text_with_newline)
+    with parser_lock:
+        # Parse with C++ parser (this also collects comments)
+        vtl_cpp_parser.parse(text_with_newline)
 
-    # Get comments from the last parse
-    comment_tokens = vtl_cpp_parser.get_comments()
+        # Get comments from the last parse
+        comment_tokens = vtl_cpp_parser.get_comments()
 
-    comments = [generate_ast_comment(c) for c in comment_tokens]
+        comments = [generate_ast_comment(c) for c in comment_tokens]
 
-    # Parse the statements. A script with no statements (only comments or empty) yields a
-    # Start node with no children; a malformed script raises VTLSyntaxError, which must
-    # propagate instead of being silently swallowed into an empty AST.
-    ast = create_ast(text)
-    if not ast.children:
-        ast = Start(line_start=1, line_stop=1, column_start=0, column_stop=0, children=[])
+        # Parse the statements. A script with no statements (only comments or empty) yields a
+        # Start node with no children; a malformed script raises VTLSyntaxError, which must
+        # propagate instead of being silently swallowed into an empty AST.
+        ast = create_ast(text)
+        if not ast.children:
+            ast = Start(line_start=1, line_stop=1, column_start=0, column_stop=0, children=[])
 
-    ast.children.extend(comments)
-    ast.children.sort(key=lambda x: (x.line_start, x.column_start))
+        ast.children.extend(comments)
+        ast.children.sort(key=lambda x: (x.line_start, x.column_start))
 
     return ast

--- a/src/vtlengine/AST/Grammar/_cpp_parser/__init__.py
+++ b/src/vtlengine/AST/Grammar/_cpp_parser/__init__.py
@@ -1,3 +1,5 @@
+import threading
+
 from vtlengine.AST.Grammar._cpp_parser.vtl_cpp_parser import (  # type: ignore[import-untyped]
     ParseNode,
     TerminalNode,
@@ -6,12 +8,23 @@ from vtlengine.AST.Grammar._cpp_parser.vtl_cpp_parser import (  # type: ignore[i
     parse,
 )
 
+# The compiled parser keeps the tree of the LAST parse() call in a single
+# process-global buffer, and the ParseNode/TerminalNode objects returned to
+# Python hold raw pointers into it. A concurrent parse() from another thread
+# frees that buffer, leaving those pointers dangling (use-after-free, observed
+# as a corrupted AST or a segfault). Callers must therefore hold this lock
+# across parse() AND the full parse-tree traversal that materialises the Python
+# AST from it. It is re-entrant because create_ast_with_comments() parses and
+# then calls create_ast(), which parses again while still holding the lock.
+parser_lock = threading.RLock()
+
 __all__ = [
     "ParseNode",
     "TerminalNode",
     "parse",
     "get_input_text",
     "get_comments",
+    "parser_lock",
     "LITERAL_NAMES",
 ]
 

--- a/tests/Concurrency/test_thread_safety.py
+++ b/tests/Concurrency/test_thread_safety.py
@@ -4,6 +4,7 @@ Verifies that concurrent vtlengine executions using DuckDB work correctly
 when called from multiple threads in the same process.
 """
 
+import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, Optional
 
@@ -62,6 +63,40 @@ class TestConcurrentAggregation:
             assert len(df) == 3
             sums = dict(zip(df["Id_1"], df["Me_1"]))
             assert sums == {1: 30.0, 2: 70.0, 3: 50.0}
+
+
+class TestConcurrentParsing:
+    """The C++ parser keeps the last parse tree in process-global state and hands
+    Python raw pointers into it; a concurrent parse must not free it mid-traversal.
+    Different scripts per thread surface any cross-contamination, and a tiny GIL
+    switch interval widens the race window so a regression fails reliably here."""
+
+    def test_concurrent_mixed_scripts(self) -> None:
+        expectations = {
+            "DS_r <- sum(DS_1 group by Id_1);": {1: 30.0, 2: 70.0, 3: 50.0},
+            "DS_r <- max(DS_1 group by Id_1);": {1: 20.0, 2: 40.0, 3: 50.0},
+            "DS_r <- min(DS_1 group by Id_1);": {1: 10.0, 2: 30.0, 3: 50.0},
+        }
+        scripts = list(expectations)
+
+        def task(idx: int) -> Dict[Any, Any]:
+            script = scripts[idx % len(scripts)]
+            df = run(script=script, data_structures=DATA_STRUCTURES, datapoints=DATAPOINTS)[
+                "DS_r"
+            ].data
+            assert dict(zip(df["Id_1"], df["Me_1"])) == expectations[script]
+            return {}
+
+        previous_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        try:
+            for _ in range(40):
+                with ThreadPoolExecutor(max_workers=6) as executor:
+                    futures = [executor.submit(task, i) for i in range(6)]
+                    for future in as_completed(futures):
+                        future.result()
+        finally:
+            sys.setswitchinterval(previous_interval)
 
 
 class TestConcurrentAnalytic:


### PR DESCRIPTION
## Summary

Concurrent `run()`/`create_ast()` calls intermittently failed with `KeyError: 'DS_r'`,
`NotImplementedError`, wrong results, or a segfault — and flaked CI on unrelated PRs
(#890, #891, #896). Root cause: the compiled parser stores the last parse tree in a
single process-global buffer (`g_state` in `bindings.cpp`) and returns raw pointers into
it, so a second thread's `parse()` frees a tree the first thread is still traversing in
`visitStart()` (use-after-free).

This serializes `parse()` and the full parse-tree traversal under a re-entrant
`parser_lock` in `create_ast()` and `create_ast_with_comments()`. Once `visitStart()`
returns, the Python AST holds no C++ pointers, so only parsing is serialized —
DuckDB/pandas execution still runs concurrently. Adds a regression test that reproduces
the corruption reliably (mixed scripts across threads under a tiny GIL switch interval).

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable) — n/a

## Impact / Risk

- Breaking changes? No. Parsing is now serialized across threads, but it was never safe
  concurrently; execution stays parallel.
- Data/SDMX compatibility concerns? None.
- Notes for release/changelog? Fixes a concurrency crash/corruption in the parser.

## Notes

Follow-up option (own issue/PR): make the C++ `parse()` return a self-contained tree so
parsing can also run in parallel. Related: #626 (DuckDB-layer thread-safety, already fixed).

Fixes #901
