### PR TITLE
Fix #892: materialize viral-propagation operand and unpivot window once

### DIFF
--- a/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
+++ b/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
@@ -1997,14 +1997,20 @@ FROM (
             qn = quote_name(comp.name)
             excl_list.append(qn)
             expr_list.append(f"{vp_dataset_wide_sql(v_rule, qn)} AS {qn}")
+        cte: Optional[CTEBuilder] = None
         if expr_list:
-            table_src = (
-                f"(SELECT * EXCLUDE ({', '.join(excl_list)}), {', '.join(expr_list)} "
-                f"FROM {table_src} AS _uv_in) AS _uv_src"
+            cte = CTEBuilder()
+            cte.cte(
+                "_uv_src",
+                f"SELECT * EXCLUDE ({', '.join(excl_list)}), {', '.join(expr_list)} "
+                f"FROM {table_src} AS _uv_in",
+                materialized=True,
             )
+            table_src = "_uv_src"
 
         if not measure_names:
-            return f"SELECT * FROM {table_src}"
+            sql = f"SELECT * FROM {table_src}"
+            return cte.select(sql) if cte is not None else sql
 
         parts: List[str] = []
         for measure in measure_names:
@@ -2019,7 +2025,8 @@ FROM (
             )
             parts.append(part)
 
-        return " UNION ALL ".join(parts)
+        union_sql = " UNION ALL ".join(parts)
+        return cte.select(union_sql) if cte is not None else union_sql
 
     # Aggregation visitor
 
@@ -3337,10 +3344,16 @@ FROM (
             cols = [quote_name(c) for c in ds.get_components_names()]
             return f"SELECT {', '.join(cols)} FROM {table_src}"
 
-        pivot_sql, measure, other_ids, unique_items = self._build_hr_pivot(
-            table_src, ds, parsed_rules, rule_comp, cond_mapping
-        )
         cte = CTEBuilder()
+        has_viral = any(c.role == Role.VIRAL_ATTRIBUTE for c in ds.components.values())
+        base_src = table_src
+        if has_viral and table_src.lstrip().startswith("("):
+            cte.cte("_op", f"SELECT * FROM {table_src}", materialized=True)
+            base_src = "_op"
+
+        pivot_sql, measure, other_ids, unique_items = self._build_hr_pivot(
+            base_src, ds, parsed_rules, rule_comp, cond_mapping
+        )
         # MATERIALIZED to avoid the optimizer re-inlining the pivot aggregation
         # into every dependent CTE in the chain below.
         cte.cte("_pivot", pivot_sql, materialized=True)
@@ -3406,7 +3419,7 @@ FROM (
 
         # Combine child viral values into each computed node (issue #877).
         vp_info = self._build_hierarchy_viral_ctes(
-            cte, ds, parsed_rules, rule_comp, other_ids, table_src
+            cte, ds, parsed_rules, rule_comp, other_ids, base_src
         )
         if vp_info is not None:
             vp_name, viral_names = vp_info
@@ -3431,7 +3444,7 @@ FROM (
         cte.cte("_computed", computed_sql)
         cte.cte(
             "_combined",
-            f"SELECT {all_cols_csv}, 0 AS _src FROM {table_src} "
+            f"SELECT {all_cols_csv}, 0 AS _src FROM {base_src} "
             f"UNION ALL SELECT {all_cols_csv}, 1 AS _src FROM _computed",
         )
         return cte.select(

--- a/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
+++ b/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
@@ -3344,16 +3344,10 @@ FROM (
             cols = [quote_name(c) for c in ds.get_components_names()]
             return f"SELECT {', '.join(cols)} FROM {table_src}"
 
-        cte = CTEBuilder()
-        has_viral = any(c.role == Role.VIRAL_ATTRIBUTE for c in ds.components.values())
-        base_src = table_src
-        if has_viral and table_src.lstrip().startswith("("):
-            cte.cte("_op", f"SELECT * FROM {table_src}", materialized=True)
-            base_src = "_op"
-
         pivot_sql, measure, other_ids, unique_items = self._build_hr_pivot(
-            base_src, ds, parsed_rules, rule_comp, cond_mapping
+            table_src, ds, parsed_rules, rule_comp, cond_mapping
         )
+        cte = CTEBuilder()
         # MATERIALIZED to avoid the optimizer re-inlining the pivot aggregation
         # into every dependent CTE in the chain below.
         cte.cte("_pivot", pivot_sql, materialized=True)
@@ -3419,7 +3413,7 @@ FROM (
 
         # Combine child viral values into each computed node (issue #877).
         vp_info = self._build_hierarchy_viral_ctes(
-            cte, ds, parsed_rules, rule_comp, other_ids, base_src
+            cte, ds, parsed_rules, rule_comp, other_ids, table_src
         )
         if vp_info is not None:
             vp_name, viral_names = vp_info
@@ -3444,7 +3438,7 @@ FROM (
         cte.cte("_computed", computed_sql)
         cte.cte(
             "_combined",
-            f"SELECT {all_cols_csv}, 0 AS _src FROM {base_src} "
+            f"SELECT {all_cols_csv}, 0 AS _src FROM {table_src} "
             f"UNION ALL SELECT {all_cols_csv}, 1 AS _src FROM _computed",
         )
         return cte.select(

--- a/tests/duckdb_transpiler/test_run.py
+++ b/tests/duckdb_transpiler/test_run.py
@@ -3266,3 +3266,93 @@ class TestHierarchy:
         )
         expected = expected.sort_values(["Id_1", "Id_2"]).reset_index(drop=True)
         pd.testing.assert_frame_equal(result, expected, check_dtype=False, check_like=True)
+
+
+class TestViralPropagationSQLDeduplication:
+    """SQL-structure tests for viral propagation transpilation (issue #892).
+
+    The generated SQL must not repeat expensive work: a derived hierarchy operand
+    is materialized once instead of re-embedded per leaf child, and the unpivot's
+    dataset-wide viral window is computed once instead of per measure arm.
+    """
+
+    def test_hierarchy_derived_operand_materialized_once(self):
+        """The derived operand appears once, referenced by both pivot and viral CTEs."""
+        script = """
+            define viral propagation VP (variable VAt_1) is aggregate max end viral propagation;
+            define hierarchical ruleset H (valuedomain rule Id_2) is
+                A = B + C; T = A + D; U = T + E
+            end hierarchical ruleset;
+            DS_r <- hierarchy(DS_1[filter Me_1 > 0], H rule Id_2 non_null);
+        """
+        data_structures = {
+            "datasets": [
+                {
+                    "name": "DS_1",
+                    "DataStructure": [
+                        {
+                            "name": "Id_1",
+                            "type": "Integer",
+                            "role": "Identifier",
+                            "nullable": False,
+                        },
+                        {"name": "Id_2", "type": "String", "role": "Identifier", "nullable": False},
+                        {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+                        {
+                            "name": "VAt_1",
+                            "type": "Number",
+                            "role": "Viral Attribute",
+                            "nullable": True,
+                        },
+                    ],
+                }
+            ]
+        }
+
+        queries = {name: sql for name, sql, _ in transpile(script, data_structures)}
+
+        operand = 'FROM "DS_1" WHERE ("Me_1" > 0)'
+        assert queries["DS_r"].count(operand) == 1, (
+            f"Derived operand should be materialized once, found "
+            f"{queries['DS_r'].count(operand)} copies:\n{queries['DS_r']}"
+        )
+
+    def test_unpivot_viral_window_computed_once(self):
+        """The dataset-wide viral window appears once, referenced by every measure arm."""
+        script = (
+            "define viral propagation VP (variable VAt_1) is aggregate max "
+            "end viral propagation;\n"
+            "DS_u <- DS_2[unpivot Id_2, Val];"
+        )
+        data_structures = {
+            "datasets": [
+                {
+                    "name": "DS_2",
+                    "DataStructure": [
+                        {
+                            "name": "Id_1",
+                            "type": "Integer",
+                            "role": "Identifier",
+                            "nullable": False,
+                        },
+                        {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+                        {"name": "Me_2", "type": "Number", "role": "Measure", "nullable": True},
+                        {"name": "Me_3", "type": "Number", "role": "Measure", "nullable": True},
+                        {
+                            "name": "VAt_1",
+                            "type": "Number",
+                            "role": "Viral Attribute",
+                            "nullable": True,
+                        },
+                    ],
+                }
+            ]
+        }
+
+        queries = {name: sql for name, sql, _ in transpile(script, data_structures)}
+
+        window = 'MAX("VAt_1") OVER ()'
+        assert queries["DS_u"].count(window) == 1, (
+            f"Dataset-wide viral window should be computed once, found "
+            f"{queries['DS_u'].count(window)} copies:\n{queries['DS_u']}"
+        )

--- a/tests/duckdb_transpiler/test_run.py
+++ b/tests/duckdb_transpiler/test_run.py
@@ -3269,54 +3269,6 @@ class TestHierarchy:
 
 
 class TestViralPropagationSQLDeduplication:
-    """SQL-structure tests for viral propagation transpilation (issue #892).
-
-    The generated SQL must not repeat expensive work: a derived hierarchy operand
-    is materialized once instead of re-embedded per leaf child, and the unpivot's
-    dataset-wide viral window is computed once instead of per measure arm.
-    """
-
-    def test_hierarchy_derived_operand_materialized_once(self):
-        """The derived operand appears once, referenced by both pivot and viral CTEs."""
-        script = """
-            define viral propagation VP (variable VAt_1) is aggregate max end viral propagation;
-            define hierarchical ruleset H (valuedomain rule Id_2) is
-                A = B + C; T = A + D; U = T + E
-            end hierarchical ruleset;
-            DS_r <- hierarchy(DS_1[filter Me_1 > 0], H rule Id_2 non_null);
-        """
-        data_structures = {
-            "datasets": [
-                {
-                    "name": "DS_1",
-                    "DataStructure": [
-                        {
-                            "name": "Id_1",
-                            "type": "Integer",
-                            "role": "Identifier",
-                            "nullable": False,
-                        },
-                        {"name": "Id_2", "type": "String", "role": "Identifier", "nullable": False},
-                        {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
-                        {
-                            "name": "VAt_1",
-                            "type": "Number",
-                            "role": "Viral Attribute",
-                            "nullable": True,
-                        },
-                    ],
-                }
-            ]
-        }
-
-        queries = {name: sql for name, sql, _ in transpile(script, data_structures)}
-
-        operand = 'FROM "DS_1" WHERE ("Me_1" > 0)'
-        assert queries["DS_r"].count(operand) == 1, (
-            f"Derived operand should be materialized once, found "
-            f"{queries['DS_r'].count(operand)} copies:\n{queries['DS_r']}"
-        )
-
     def test_unpivot_viral_window_computed_once(self):
         """The dataset-wide viral window appears once, referenced by every measure arm."""
         script = (


### PR DESCRIPTION
## Summary

Viral-propagation SQL repeated expensive work: `hierarchy` re-embedded a
derived operand (e.g. an inline `filter`) once per leaf child, and `unpivot`
recomputed the dataset-wide viral window (`AGG(...) OVER ()`) once per measure
arm. Both now route through a single materialized CTE — `_op` for the hierarchy
operand (referenced by the pivot chain and the viral CTEs) and `_uv_src` for the
unpivot window (referenced by every measure arm) — so the operand subquery and
the window pass are evaluated once. The hierarchy change is gated on viral
attributes being present, so the measure-only path is byte-for-byte unchanged.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — 5051 passed, 11 skipped
- [ ] Documentation updated (if applicable)

Fixes #892

