### PR TITLE
Fix #906: execute viral propagation only at combination points

### DIFF
--- a/src/vtlengine/Exceptions/messages.py
+++ b/src/vtlengine/Exceptions/messages.py
@@ -1057,8 +1057,10 @@ centralised_messages = {
     "1-3-3-6": {
         "message": "Viral attribute {name} has no viral propagation rule; declare a "
         "'define viral propagation' rule for it.",
-        "description": "Raised when a viral attribute appears in a result without a "
-        "define viral propagation rule. Every viral attribute must declare one.",
+        "description": "Raised when a viral attribute is combined -- in an operation over "
+        "two or more datasets, an aggregation/analytic group-by, or a hierarchy roll-up -- "
+        "without a 'define viral propagation' rule. Viral attributes that are only copied "
+        "through row-preserving operators do not require a rule.",
     },
     # ---------- Interpreter ----------
     "1-3-5": {

--- a/src/vtlengine/Interpreter/__init__.py
+++ b/src/vtlengine/Interpreter/__init__.py
@@ -283,11 +283,6 @@ class InterpreterAnalyzer(ASTTemplate):
             # Enforce output dtypes match DataStructure declarations
             if isinstance(result, Dataset):
                 result.enforce_dtypes()
-                # Every viral attribute must declare a viral propagation rule (issue #877).
-                vp_registry = get_current_registry()
-                for viral_comp in result.get_viral_attributes():
-                    if vp_registry.rule_for(viral_comp) is None:
-                        raise SemanticError("1-3-3-6", name=viral_comp.name)
 
             # Removing output dataset
             vtlengine.Exceptions.dataset_output = None

--- a/src/vtlengine/Operators/Aggregation.py
+++ b/src/vtlengine/Operators/Aggregation.py
@@ -35,7 +35,7 @@ from vtlengine.DataTypes.TimeHandling import (
 )
 from vtlengine.Exceptions import RunTimeError, SemanticError
 from vtlengine.Model import Component, Dataset, Role
-from vtlengine.ViralPropagation import get_current_registry
+from vtlengine.ViralPropagation import get_current_registry, require_rules
 
 
 def extract_grouping_identifiers(
@@ -171,6 +171,9 @@ class Aggregation(Operator.Unary):
             )
             result_components["int_var"] = new_comp
 
+        # Aggregation combines the data points of each group, so the surviving viral
+        # attributes are combined and require a propagation rule (issue #906).
+        require_rules(operand.get_viral_attributes())
         # VDS is handled in visit_Aggregation
         return Dataset(name="result", components=result_components, data=None)
 

--- a/src/vtlengine/Operators/Analytic.py
+++ b/src/vtlengine/Operators/Analytic.py
@@ -40,7 +40,7 @@ from vtlengine.DataTypes import (
 from vtlengine.Exceptions import RunTimeError, SemanticError
 from vtlengine.Model import Component, Dataset, Role
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
-from vtlengine.ViralPropagation import get_current_registry
+from vtlengine.ViralPropagation import get_current_registry, require_rules
 
 return_integer_operators = [MAX, MIN, SUM]
 
@@ -210,6 +210,9 @@ class Analytic(Operator.Unary):
                     nullable=nullable,
                 )
         dataset_name = VirtualCounter._new_ds_name()
+        # Analytic combines the data points within each partition, so the surviving viral
+        # attributes are combined and require a propagation rule (issue #906).
+        require_rules(operand.get_viral_attributes())
         return Dataset(name=dataset_name, components=result_components, data=None)
 
     @classmethod

--- a/src/vtlengine/Operators/Clause.py
+++ b/src/vtlengine/Operators/Clause.py
@@ -17,7 +17,6 @@ from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import Component, DataComponent, Dataset, Role, Scalar
 from vtlengine.Operators import Operator
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
-from vtlengine.ViralPropagation import get_current_registry
 
 
 class Calc(Operator):
@@ -313,12 +312,9 @@ class Unpivot(Operator):
         result_dataset = cls.validate(operands, dataset)
         if dataset.data is not None:
             viral_names = dataset.get_viral_attributes_names()
+            # Unpivot replicates each source row's viral attribute values across the
+            # unpivoted rows (kept as id_vars); no rule is executed — copy only (issue #906).
             src = dataset.data
-            if viral_names:
-                # Execute the rule over the source (one value per source row) BEFORE the
-                # melt, so aggregate rules are not distorted by row replication (issue #877).
-                src = src.copy()
-                get_current_registry().apply_row_preserving(src, viral_names)
             result_dataset.data = src.melt(
                 id_vars=dataset.get_identifiers_names() + viral_names,
                 value_vars=dataset.get_measures_names(),

--- a/src/vtlengine/Operators/Conditional.py
+++ b/src/vtlengine/Operators/Conditional.py
@@ -287,8 +287,9 @@ class Nvl(Binary):
                     else:
                         result.data = left.data.fillna(right.value)
                 else:
+                    # nvl is single-operand: the primary operand's viral attributes are
+                    # copied through unchanged; no rule is executed (issue #906).
                     result.data = left.data.fillna(right.data)
-                    _combine_viral_attributes(result, [left, right])
                 if isinstance(result, Dataset):
                     result.data = result.data[result.get_components_names()]
         return result

--- a/src/vtlengine/Operators/Conditional.py
+++ b/src/vtlengine/Operators/Conditional.py
@@ -13,7 +13,11 @@ from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import DataComponent, Dataset, Role, Scalar
 from vtlengine.Operators import Binary, Operator
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
-from vtlengine.ViralPropagation import get_current_registry
+from vtlengine.ViralPropagation import (
+    combined_viral_components,
+    get_current_registry,
+    require_rules,
+)
 
 COND_COL = "__cond__"
 
@@ -237,6 +241,11 @@ class If(Operator):
             if left.get_identifiers() != condition.get_identifiers():
                 raise SemanticError("1-1-9-6", op=cls.op)
         result_components = {comp_name: copy(comp) for comp_name, comp in left.components.items()}
+        # if-then-else over two datasets combines their data points per row, so viral
+        # attributes carried by both branches require a propagation rule (issue #906).
+        require_rules(
+            combined_viral_components([b for b in (left, right) if isinstance(b, Dataset)])
+        )
         return Dataset(name=dataset_name, components=result_components, data=None)
 
 
@@ -468,4 +477,7 @@ class Case(Operator):
             if isinstance(op, Dataset) and op.get_components_names() != comp_names:
                 raise SemanticError("2-1-9-7", op=cls.op)
 
+        # case over two or more datasets combines their data points, so viral attributes
+        # carried by two or more branches require a propagation rule (issue #906).
+        require_rules(combined_viral_components([op for op in ops if isinstance(op, Dataset)]))
         return Dataset(name=dataset_name, components=components, data=None)

--- a/src/vtlengine/Operators/HROperators.py
+++ b/src/vtlengine/Operators/HROperators.py
@@ -15,7 +15,7 @@ from vtlengine.Utils._number_config import (
     numbers_are_greater_equal,
     numbers_are_less_equal,
 )
-from vtlengine.ViralPropagation import get_current_registry
+from vtlengine.ViralPropagation import get_current_registry, require_rules
 
 REMOVE = "REMOVE_VALUE"
 
@@ -258,6 +258,9 @@ class Hierarchy(Operators.Operator):
         # Viral attributes propagate to the hierarchy result (issue #877).
         for viral_comp in viral_components or []:
             result_components[viral_comp.name] = copy(viral_comp)
+        # The roll-up combines child nodes into each computed node, so the combined viral
+        # attributes require a propagation rule (issue #906).
+        require_rules(viral_components or [])
         return Dataset(name=dataset_name, components=result_components, data=None)
 
     @staticmethod

--- a/src/vtlengine/Operators/Join.py
+++ b/src/vtlengine/Operators/Join.py
@@ -11,7 +11,7 @@ from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import Component, Dataset, Role
 from vtlengine.Operators import Operator, _id_type_promotion_join_keys
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
-from vtlengine.ViralPropagation import get_current_registry
+from vtlengine.ViralPropagation import get_current_registry, require_rules
 
 
 def merged_viral_attribute_names(
@@ -84,6 +84,15 @@ class Join(Operator):
         # (values combined via the viral propagation rule at execution time)
         # instead of being #-qualified like other shared components.
         viral_common = merged_viral_attribute_names([op.components for op in operands], set(using))
+        # A merged viral attribute has its data points combined across operands, so it
+        # requires a propagation rule (issue #906).
+        merged_viral_comps = {
+            name: op.components[name]
+            for op in operands
+            for name in viral_common
+            if name in op.components
+        }
+        require_rules(merged_viral_comps.values())
 
         for op in operands:
             for comp in op.components.values():

--- a/src/vtlengine/Operators/Numeric.py
+++ b/src/vtlengine/Operators/Numeric.py
@@ -32,7 +32,6 @@ from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import DataComponent, Dataset, Scalar
 from vtlengine.Operators import ALL_MODEL_DATA_TYPES
 from vtlengine.Utils._number_config import get_effective_numeric_digits
-from vtlengine.ViralPropagation import get_current_registry
 
 
 class Unary(Operator.Unary):
@@ -381,10 +380,7 @@ class Parameterized(Unary):
             + operand.get_measures_names()
             + operand.get_viral_attributes_names()
         ]
-        # Execute the viral propagation rule on the (row-preserving) result (issue #877).
-        get_current_registry().apply_row_preserving(
-            result.data, result.get_viral_attributes_names()
-        )
+        # Row-preserving operator: viral attributes are copied through unchanged (issue #906).
         cls.modify_measure_column(result)
         return result
 

--- a/src/vtlengine/Operators/String.py
+++ b/src/vtlengine/Operators/String.py
@@ -25,7 +25,6 @@ from vtlengine.AST.Grammar.tokens import (
 from vtlengine.DataTypes import Integer, Number, String, check_unary_implicit_promotion
 from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import DataComponent, Dataset, Role, Scalar
-from vtlengine.ViralPropagation import get_current_registry
 
 
 class Unary(Operator.Unary):
@@ -190,10 +189,7 @@ class Parameterized(Unary):
 
         cols_to_keep = [c.name for c in operand.get_components() if c.role != Role.ATTRIBUTE]
         result.data = result.data[cols_to_keep]
-        # Execute the viral propagation rule on the (row-preserving) result (issue #877).
-        get_current_registry().apply_row_preserving(
-            result.data, result.get_viral_attributes_names()
-        )
+        # Row-preserving operator: viral attributes are copied through unchanged (issue #906).
         cls.modify_measure_column(result)
         return result
 
@@ -624,10 +620,7 @@ class Instr(Parameterized):
                 )
         cols_to_keep = [c.name for c in operand.get_components() if c.role != Role.ATTRIBUTE]
         result.data = result.data[cols_to_keep]
-        # Execute the viral propagation rule on the (row-preserving) result (issue #877).
-        get_current_registry().apply_row_preserving(
-            result.data, result.get_viral_attributes_names()
-        )
+        # Row-preserving operator: viral attributes are copied through unchanged (issue #906).
         cls.modify_measure_column(result)
         return result
 

--- a/src/vtlengine/Operators/Time.py
+++ b/src/vtlengine/Operators/Time.py
@@ -45,7 +45,6 @@ from vtlengine.DataTypes.TimeHandling import (
 from vtlengine.Exceptions import RunTimeError, SemanticError
 from vtlengine.Model import Component, DataComponent, Dataset, Role, Scalar
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
-from vtlengine.ViralPropagation import get_current_registry
 
 
 class Time(Operators.Operator):
@@ -305,10 +304,7 @@ class Period_indicator(Unary):
         )
         period_series: Any = result.data[cls.time_id].map(cls._get_period)
         result.data["duration_var"] = period_series
-        # Execute the viral propagation rule on the (row-preserving) result (issue #877).
-        get_current_registry().apply_row_preserving(
-            result.data, result.get_viral_attributes_names()
-        )
+        # Row-preserving operator: viral attributes are copied through unchanged (issue #906).
         return result
 
 

--- a/src/vtlengine/Operators/Validation.py
+++ b/src/vtlengine/Operators/Validation.py
@@ -16,7 +16,6 @@ from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import Component, Dataset, Role
 from vtlengine.Operators import Operator
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
-from vtlengine.ViralPropagation import get_current_registry
 
 
 # noinspection PyTypeChecker
@@ -255,9 +254,10 @@ class Validation(Operator):
                 + validation_measures
             ]
 
-        # Re-attach viral attributes matched per datapoint on the identifiers, then execute
-        # the propagation rule (issue #877). Source: the operand's own data (check_datapoint)
-        # or the captured pre-strip viral (check_hierarchy).
+        # Re-attach viral attributes matched per datapoint on the identifiers (copied, not
+        # combined: check_datapoint/check_hierarchy are row-preserving validations) (issue
+        # #906). Source: the operand's own data (check_datapoint) or the captured pre-strip
+        # viral (check_hierarchy).
         viral_comps = (
             viral_components
             if viral_components is not None
@@ -271,7 +271,6 @@ class Validation(Operator):
             ]
             viral_src = viral_src_data[join_ids + viral_names].drop_duplicates(subset=join_ids)
             result.data = result.data.merge(viral_src, on=join_ids, how="left")
-            get_current_registry().apply_row_preserving(result.data, viral_names)
 
         result.data = result.data[result.get_components_names()]
         return result

--- a/src/vtlengine/Operators/__init__.py
+++ b/src/vtlengine/Operators/__init__.py
@@ -727,10 +727,8 @@ class Binary(Operator):
             + dataset.get_viral_attributes_names()
         )
         result_dataset.data = result_dataset.data[cols_to_keep]
-        # Execute the viral propagation rule on the (row-preserving) result (issue #877).
-        get_current_registry().apply_row_preserving(
-            result_dataset.data, result_dataset.get_viral_attributes_names()
-        )
+        # Row-preserving operator: viral attributes are copied through unchanged (they are
+        # not combined), per the VTL 2.2 attribute propagation rule (issue #906).
         cls.modify_measure_column(result_dataset)
         return result_dataset
 
@@ -1001,10 +999,8 @@ class Unary(Operator):
         result_data = result_data[cols_to_keep]
 
         result_dataset.data = result_data
-        # Execute the viral propagation rule on the (row-preserving) result (issue #877).
-        get_current_registry().apply_row_preserving(
-            result_dataset.data, result_dataset.get_viral_attributes_names()
-        )
+        # Row-preserving operator: viral attributes are copied through unchanged (they are
+        # not combined), per the VTL 2.2 attribute propagation rule (issue #906).
         cls.modify_measure_column(result_dataset)
         return result_dataset
 

--- a/src/vtlengine/Operators/__init__.py
+++ b/src/vtlengine/Operators/__init__.py
@@ -34,7 +34,11 @@ from vtlengine.DataTypes.TimeHandling import (
 from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import Component, DataComponent, Dataset, Role, Scalar, ScalarSet
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
-from vtlengine.ViralPropagation import get_current_registry
+from vtlengine.ViralPropagation import (
+    combined_viral_components,
+    get_current_registry,
+    require_rules,
+)
 
 ALL_MODEL_DATA_TYPES = Union[Dataset, Scalar, DataComponent]
 
@@ -350,6 +354,11 @@ class Binary(Operator):
                 left_comp = left_operand.components[comp.name]
                 right_comp = right_operand.components[comp.name]
                 comp.nullable = left_comp.nullable or right_comp.nullable
+
+        # Viral attributes present in BOTH operands have their data points merged, so they
+        # are combined and require a propagation rule; a viral attribute in a single operand
+        # is copied through and needs none (issue #906).
+        require_rules(combined_viral_components([left_operand, right_operand]))
 
         result_dataset = Dataset(name=dataset_name, components=result_components, data=None)
         cls.apply_return_type_dataset(result_dataset, left_operand, right_operand)

--- a/src/vtlengine/ViralPropagation/__init__.py
+++ b/src/vtlengine/ViralPropagation/__init__.py
@@ -9,7 +9,7 @@ in :mod:`vtlengine.ViralPropagation.sql`.
 
 from dataclasses import dataclass, field
 from functools import reduce
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
 
@@ -198,3 +198,35 @@ def set_current_registry(registry: ViralPropagationRegistry) -> None:
     """Set the current viral propagation registry (called by Interpreter)."""
     global _current_registry  # noqa: PLW0603
     _current_registry = registry
+
+
+def require_rules(components: Iterable[Any]) -> None:
+    """Raise SemanticError 1-3-3-6 for any viral component lacking a propagation rule.
+
+    Call this at the combination points defined by the VTL 2.2 attribute propagation
+    rule (an operation over two or more datasets, an aggregation/analytic group-by, or
+    a hierarchy roll-up), where the default propagation algorithm must be executed. A
+    viral attribute that is only copied through (row-preserving operators) needs no rule.
+    """
+    from vtlengine.Exceptions import SemanticError  # local import avoids an import cycle
+
+    registry = get_current_registry()
+    for comp in components:
+        if registry.rule_for(comp) is None:
+            raise SemanticError("1-3-3-6", name=comp.name)
+
+
+def combined_viral_components(operands: Iterable[Any]) -> List[Any]:
+    """Return the viral components combined across ``operands``.
+
+    A viral attribute whose data points are combined appears (by name) as a viral
+    attribute in two or more operands; those require a propagation rule. A viral
+    attribute present in a single operand is copied through and needs no rule.
+    """
+    counts: Dict[str, int] = {}
+    comp_by_name: Dict[str, Any] = {}
+    for op in operands:
+        for comp in op.get_viral_attributes():
+            counts[comp.name] = counts.get(comp.name, 0) + 1
+            comp_by_name[comp.name] = comp
+    return [comp_by_name[name] for name, n in counts.items() if n >= 2]

--- a/src/vtlengine/ViralPropagation/__init__.py
+++ b/src/vtlengine/ViralPropagation/__init__.py
@@ -146,30 +146,6 @@ class ViralPropagationRegistry:
         # Enumerated: reduce pairwise (associative + commutative guarantees correctness)
         return reduce(lambda a, b: self.resolve_pair(variable_name, a, b), values)
 
-    def apply_row_preserving(self, data: pd.DataFrame, viral_names: List[str]) -> None:
-        """Execute the propagation rule on each viral column of a row-preserving
-        operator result, in place.
-
-        Aggregate rules collapse the whole column to a single value applied to every
-        row; enumerated rules map each value (matching unary clause, else default); a
-        no-rule attribute is left unchanged.
-        """
-        for name in viral_names:
-            if name not in data.columns:
-                continue
-            rule = self.get_rule_for_variable(name)
-            if rule is None:
-                continue
-            col_dtype = data[name].dtype
-            if rule.aggregate_function is not None:
-                value = self.resolve_group(name, list(data[name]))
-                new_col = pd.Series([value] * len(data), index=data.index)
-            else:
-                new_col = pd.Series(
-                    [self.resolve_single(name, v) for v in data[name]], index=data.index
-                )
-            data[name] = new_col.astype(col_dtype)
-
     def clear(self) -> None:
         """Clear all registered rules."""
         self._variable_rules.clear()

--- a/src/vtlengine/ViralPropagation/sql.py
+++ b/src/vtlengine/ViralPropagation/sql.py
@@ -115,14 +115,3 @@ def vp_group_sql_windowed(rule: ViralPropagationRule, col_ref: str, over_clause:
 def vp_no_rule_group_sql(col_ref: str) -> str:
     """Group no-rule keep: copy the value of a single-row group, else NULL."""
     return f"CASE WHEN COUNT(*) = 1 THEN MAX({col_ref}) ELSE NULL END"
-
-
-def vp_dataset_wide_sql(rule: ViralPropagationRule, col_ref: str) -> str:
-    """SQL executing the rule over a whole row-preserving operator result.
-
-    Aggregate rules collapse every viral value to one (``AGG(col) OVER ()``) applied
-    to every row; enumerated rules map each value per row.
-    """
-    if rule.aggregate_function is not None:
-        return f"{_AGG_GROUP[rule.aggregate_function]}({col_ref}) OVER ()"
-    return _enumerated_single_case(rule, col_ref)

--- a/src/vtlengine/ViralPropagation/sql.py
+++ b/src/vtlengine/ViralPropagation/sql.py
@@ -96,20 +96,35 @@ def vp_reduce_refs(rule: ViralPropagationRule, refs: List[str]) -> str:
     return acc
 
 
+def _enumerated_group_sql(rule: ViralPropagationRule, lst: str) -> str:
+    """Combine an enumerated rule over a group given as a DuckDB list expression ``lst``.
+
+    Mirrors ``resolve_group`` in the pandas path: an empty group is NULL, a single
+    value goes through the unary-clause mapping (``resolve_single``), and two or more
+    values are folded pairwise. ``list_reduce`` alone would skip the lambda for a
+    one-element list, leaving a lone value unmapped, so the single case is explicit.
+    """
+    single = _enumerated_single_case(rule, f"({lst})[1]")
+    pair = _enumerated_case(rule, "acc", "x")
+    return (
+        f"CASE WHEN len({lst}) = 0 THEN NULL "
+        f"WHEN len({lst}) = 1 THEN {single} "
+        f"ELSE list_reduce({lst}, (acc, x) -> {pair}) END"
+    )
+
+
 def vp_group_sql(rule: ViralPropagationRule, col_ref: str) -> str:
     """SQL aggregate expression combining a group of viral values."""
     if rule.aggregate_function is not None:
         return f"{_AGG_GROUP[rule.aggregate_function]}({col_ref})"
-    case = _enumerated_case(rule, "acc", "x")
-    return f"list_reduce(list({col_ref}), (acc, x) -> {case})"
+    return _enumerated_group_sql(rule, f"list({col_ref})")
 
 
 def vp_group_sql_windowed(rule: ViralPropagationRule, col_ref: str, over_clause: str) -> str:
     """Windowed form of vp_group_sql for analytic invocation (... OVER (window))."""
     if rule.aggregate_function is not None:
         return f"{_AGG_GROUP[rule.aggregate_function]}({col_ref}) OVER ({over_clause})"
-    case = _enumerated_case(rule, "acc", "x")
-    return f"list_reduce(list({col_ref}) OVER ({over_clause}), (acc, x) -> {case})"
+    return _enumerated_group_sql(rule, f"list({col_ref}) OVER ({over_clause})")
 
 
 def vp_no_rule_group_sql(col_ref: str) -> str:

--- a/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
+++ b/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
@@ -47,7 +47,6 @@ from vtlengine.Model import Component, Dataset, ExternalRoutine, Role, Scalar, V
 from vtlengine.Operators.Join import merged_viral_attribute_names
 from vtlengine.ViralPropagation import get_current_registry
 from vtlengine.ViralPropagation.sql import (
-    vp_dataset_wide_sql,
     vp_group_sql,
     vp_group_sql_windowed,
     vp_no_rule_group_sql,
@@ -584,16 +583,9 @@ class SQLTranspiler(StructureVisitor, ASTTemplate):
                 if viral_expr_fn is not None:
                     cols.append(f"{viral_expr_fn(name, comp)} AS {quote_name(name)}")
                 elif output_ds is not None and name in output_ds.components:
-                    # Row-preserving op: execute the viral propagation rule over the
-                    # result (aggregate rules collapse dataset-wide, enumerated map per
-                    # row); no rule = passthrough. Only when the output keeps it (issue #877).
-                    rule = get_current_registry().rule_for(comp)
-                    if rule is None:
-                        cols.append(quote_name(name))
-                    else:
-                        cols.append(
-                            f"{vp_dataset_wide_sql(rule, quote_name(name))} AS {quote_name(name)}"
-                        )
+                    # Row-preserving op: data points are not combined, so the viral
+                    # attribute is copied through unchanged (issue #906).
+                    cols.append(quote_name(name))
 
         return SQLBuilder().select(*cols).from_table(table_src).build()
 
@@ -737,6 +729,64 @@ class SQLTranspiler(StructureVisitor, ASTTemplate):
         # Typed or generic registry lookup, with function-call fallback
         return registry.sql(op, left_ref, right_ref, data_type=dt)
 
+    def _ds_ds_viral_cols(
+        self,
+        op: str,
+        left_ds: Dataset,
+        right_ds: Dataset,
+        output_ds: Optional[Dataset],
+        alias_a: str,
+        alias_b: str,
+    ) -> List[str]:
+        """Build the viral-attribute SELECT columns for a two-dataset binary op.
+
+        Operators that combine data points run the propagation rule (``vp_pair_sql``);
+        ``nvl`` is single-operand and copies the primary operand (COALESCE-filled) (#906).
+        A viral attribute present in only one operand is copied from that operand.
+        """
+        vp_registry = get_current_registry()
+        left_viral = {n for n, c in left_ds.components.items() if c.role == Role.VIRAL_ATTRIBUTE}
+        right_viral = {n for n, c in right_ds.components.items() if c.role == Role.VIRAL_ATTRIBUTE}
+        if output_ds is not None:
+            viral_names = [
+                n for n, c in output_ds.components.items() if c.role == Role.VIRAL_ATTRIBUTE
+            ]
+        else:
+            viral_names = sorted(left_viral | right_viral)
+        result: List[str] = []
+        for name in viral_names:
+            qn = quote_name(name)
+            in_left = name in left_viral
+            in_right = name in right_viral
+            if op == tokens.NVL:
+                # nvl copies the primary operand's viral value, filling nulls from the
+                # secondary operand; no rule is run (issue #906).
+                if in_left and in_right:
+                    result.append(f"COALESCE({alias_a}.{qn}, {alias_b}.{qn}) AS {qn}")
+                elif in_left:
+                    result.append(f"{alias_a}.{qn} AS {qn}")
+                elif in_right:
+                    result.append(f"{alias_b}.{qn} AS {qn}")
+                continue
+            if in_left and in_right:
+                comp = (
+                    output_ds.components.get(name) if output_ds else None
+                ) or left_ds.components[name]
+                rule = vp_registry.rule_for(comp)
+                if rule is None:
+                    result.append(
+                        f"CAST(NULL AS {get_duckdb_type(comp.data_type.__name__)}) AS {qn}"
+                    )
+                else:
+                    result.append(
+                        f"{vp_pair_sql(rule, f'{alias_a}.{qn}', f'{alias_b}.{qn}')} AS {qn}"
+                    )
+            elif in_left:
+                result.append(f"{alias_a}.{qn} AS {qn}")
+            elif in_right:
+                result.append(f"{alias_b}.{qn} AS {qn}")
+        return result
+
     def _build_ds_ds_binary(
         self,
         left_node: AST.AST,
@@ -809,35 +859,8 @@ class SQLTranspiler(StructureVisitor, ASTTemplate):
                 out_name = output_measure_names[0]
             cols.append(f"{expr} AS {quote_name(out_name)}")
 
-        # Viral attribute propagation: combine values present in both operands.
-        vp_registry = get_current_registry()
-        left_viral = {n for n, c in left_ds.components.items() if c.role == Role.VIRAL_ATTRIBUTE}
-        right_viral = {n for n, c in right_ds.components.items() if c.role == Role.VIRAL_ATTRIBUTE}
-        if output_ds is not None:
-            viral_names = [
-                n for n, c in output_ds.components.items() if c.role == Role.VIRAL_ATTRIBUTE
-            ]
-        else:
-            viral_names = sorted(left_viral | right_viral)
-        for name in viral_names:
-            qn = quote_name(name)
-            in_left = name in left_viral
-            in_right = name in right_viral
-            if in_left and in_right:
-                comp = (
-                    output_ds.components.get(name) if output_ds else None
-                ) or left_ds.components[name]
-                rule = vp_registry.rule_for(comp)
-                if rule is None:
-                    cols.append(f"CAST(NULL AS {get_duckdb_type(comp.data_type.__name__)}) AS {qn}")
-                else:
-                    cols.append(
-                        f"{vp_pair_sql(rule, f'{alias_a}.{qn}', f'{alias_b}.{qn}')} AS {qn}"
-                    )
-            elif in_left:
-                cols.append(f"{alias_a}.{qn} AS {qn}")
-            elif in_right:
-                cols.append(f"{alias_b}.{qn} AS {qn}")
+        # Viral attribute propagation across the two operands (issue #906).
+        cols.extend(self._ds_ds_viral_cols(op, left_ds, right_ds, output_ds, alias_a, alias_b))
 
         on_clause = self._join_on_clause(common_ids, alias_a, alias_b)
 
@@ -1013,17 +1036,12 @@ class SQLTranspiler(StructureVisitor, ASTTemplate):
                     break
 
             id_cols = [quote_name(c.name) for c in ds.get_identifiers()]
-            # Execute the viral propagation rule on the (row-preserving) result (issue #877).
-            reg = get_current_registry()
+            # Row-preserving op: viral attributes are copied through unchanged (issue #906).
             viral_cols: List[str] = []
             for v_comp in ds.components.values():
                 if v_comp.role != Role.VIRAL_ATTRIBUTE:
                     continue
-                v_qn = quote_name(v_comp.name)
-                v_rule = reg.rule_for(v_comp)
-                viral_cols.append(
-                    v_qn if v_rule is None else f"{vp_dataset_wide_sql(v_rule, v_qn)} AS {v_qn}"
-                )
+                viral_cols.append(quote_name(v_comp.name))
             extract_expr = (
                 f'vtl_period_parse({quote_name(time_id)}).period_indicator AS "duration_var"'
             )
@@ -1981,26 +1999,8 @@ FROM (
         measure_names = ds.get_measures_names()
         viral_names = ds.get_viral_attributes_names()
 
-        # Execute the rule over the whole source before the melt so aggregate rules are not
-        # distorted by row replication; each UNION arm then reads the resolved value (issue #877).
-        reg = get_current_registry()
-        excl_list: List[str] = []
-        expr_list: List[str] = []
-        for comp in ds.components.values():
-            if comp.role != Role.VIRAL_ATTRIBUTE:
-                continue
-            v_rule = reg.rule_for(comp)
-            if v_rule is None:
-                continue
-            qn = quote_name(comp.name)
-            excl_list.append(qn)
-            expr_list.append(f"{vp_dataset_wide_sql(v_rule, qn)} AS {qn}")
-        if expr_list:
-            table_src = (
-                f"(SELECT * EXCLUDE ({', '.join(excl_list)}), {', '.join(expr_list)} "
-                f"FROM {table_src} AS _uv_in) AS _uv_src"
-            )
-
+        # Viral attributes are copied (replicated) across the unpivoted rows below; no rule
+        # is executed on this row-preserving reshape (issue #906).
         if not measure_names:
             return f"SELECT * FROM {table_src}"
 
@@ -2876,15 +2876,10 @@ FROM (
         ec_sql = self._error_code_sql(rule.erCode)
         el_sql = self._error_code_sql(rule.erLevel)
         select_parts = [quote_name(c) for c in id_cols + measure_cols]
-        # Viral attributes: execute the propagation rule over the result (issue #877).
-        reg = get_current_registry()
+        # check_datapoint is row-preserving: viral attributes are copied unchanged (issue #906).
         viral_parts: List[str] = []
         for comp in viral_comps or []:
-            qn = quote_name(comp.name)
-            v_rule = reg.rule_for(comp)
-            viral_parts.append(
-                qn if v_rule is None else f"{vp_dataset_wide_sql(v_rule, qn)} AS {qn}"
-            )
+            viral_parts.append(quote_name(comp.name))
         if output_mode == "invalid":
             select_parts.append(f"'{rule_name}' AS {quote_name('ruleid')}")
             select_parts.append(f"{ec_sql} AS {quote_name('errorcode')}")
@@ -3103,17 +3098,16 @@ FROM (
         # rule over the result (issue #877).
         viral_comps = [c for c in ds.components.values() if c.role == Role.VIRAL_ATTRIBUTE]
         if viral_comps:
-            reg = get_current_registry()
+            get_current_registry()
             keys = [*other_ids, rule_comp]
             keys_q = ", ".join(quote_name(k) for k in keys)
             raw = ", ".join(quote_name(c.name) for c in viral_comps)
             cte.cte("_chv", f"SELECT {keys_q}, {raw} FROM {table_src}")
             viral_sel = []
             for c in viral_comps:
-                v_rule = reg.rule_for(c)
+                # check_hierarchy is row-preserving: viral attribute copied unchanged (#906).
                 qn = quote_name(c.name)
-                expr = f"v.{qn}" if v_rule is None else vp_dataset_wide_sql(v_rule, f"v.{qn}")
-                viral_sel.append(f"{expr} AS {qn}")
+                viral_sel.append(f"v.{qn} AS {qn}")
             join = " AND ".join(
                 f"r.{quote_name(k)} IS NOT DISTINCT FROM v.{quote_name(k)}" for k in keys
             )

--- a/tests/ViralAttributes/test_viral_operators.py
+++ b/tests/ViralAttributes/test_viral_operators.py
@@ -555,7 +555,9 @@ class TestViralAttributeUnpivot:
             assert row["VAt_1"] == expected[row["Id_1"]]
 
     @pytest.mark.parametrize("use_duckdb", BACKENDS)
-    def test_unpivot_executes_aggregate_rule(self, use_duckdb: bool) -> None:
+    def test_unpivot_copies_viral_not_aggregate(self, use_duckdb: bool) -> None:
+        """Unpivot is row-preserving: an aggregate rule must NOT collapse the viral column;
+        each source row's value is copied (replicated) across the unpivoted rows (#906)."""
         vp = "define viral propagation VP (variable VAt_1) is aggregate max end viral propagation;"
         ds = {
             "name": "DS_1",
@@ -575,8 +577,10 @@ class TestViralAttributeUnpivot:
             datapoints={"DS_1": df},
             use_duckdb=use_duckdb,
         )
-        # aggregate max over the source VAt_1 [1, 2] = 2, replicated to all 4 melted rows
-        assert list(result["DS_r"].data["VAt_1"]) == [2, 2, 2, 2]
+        # Copied per source row (NOT collapsed to the dataset-wide max 2).
+        expected = {1: 1, 2: 2}
+        for _, row in result["DS_r"].data.iterrows():
+            assert row["VAt_1"] == expected[row["Id_1"]]
 
 
 # -- Period_indicator time operator --
@@ -620,7 +624,9 @@ class TestViralAttributePeriodIndicator:
             assert row["VAt_1"] == expected[str(row["Id_1"])]
 
     @pytest.mark.parametrize("use_duckdb", BACKENDS)
-    def test_period_indicator_executes_aggregate_rule(self, use_duckdb: bool) -> None:
+    def test_period_indicator_copies_viral_not_aggregate(self, use_duckdb: bool) -> None:
+        """period_indicator is row-preserving: an aggregate rule must NOT collapse the
+        viral column; each row's value is copied unchanged (issue #906)."""
         vp = "define viral propagation VP (variable VAt_1) is aggregate max end viral propagation;"
         ds = {
             "name": "DS_1",
@@ -637,8 +643,8 @@ class TestViralAttributePeriodIndicator:
             datapoints={"DS_1": df},
             use_duckdb=use_duckdb,
         )
-        # aggregate max over the whole dataset -> 200 on every result row
-        assert list(result["DS_r"].data["VAt_1"]) == [200, 200]
+        # Copied per row (NOT collapsed to the dataset-wide max 200).
+        assert sorted(result["DS_r"].data["VAt_1"].tolist()) == [100, 200]
 
 
 # -- check_datapoint validation operator --
@@ -688,7 +694,9 @@ class TestViralAttributeCheckDatapoint:
             assert row["VAt_1"] == expected[row["Id_1"]]
 
     @pytest.mark.parametrize("use_duckdb", BACKENDS)
-    def test_check_datapoint_executes_aggregate_rule(self, use_duckdb: bool) -> None:
+    def test_check_datapoint_copies_viral_not_aggregate(self, use_duckdb: bool) -> None:
+        """check_datapoint is row-preserving: an aggregate rule must NOT collapse the viral
+        column; each source datapoint's value is copied unchanged (issue #906)."""
         vp = "define viral propagation VP (variable VAt_1) is aggregate max end viral propagation;"
         ds = {
             "name": "DS_1",
@@ -705,8 +713,9 @@ class TestViralAttributeCheckDatapoint:
             datapoints={"DS_1": df},
             use_duckdb=use_duckdb,
         )
-        # aggregate max over all datapoints -> 300 on every validation row
-        assert list(result["DS_r"].data["VAt_1"]) == [300, 300, 300]
+        # Copied per datapoint (NOT collapsed to the dataset-wide max 300).
+        d = result["DS_r"].data.sort_values("Id_1")
+        assert list(d["VAt_1"]) == [100, 200, 300]
 
 
 # -- Rule execution on row-preserving dataset-level operators (issue #877) --
@@ -719,9 +728,9 @@ _ENUM_RULE = (
 
 
 class TestViralRuleExecutionRowPreserving:
-    """Row-preserving dataset-level operators must EXECUTE the rule: aggregate rules
-    collapse over the whole dataset (one value on every row); enumerated rules map
-    per row (issue #877)."""
+    """Row-preserving dataset-level operators must COPY the viral attribute, NOT execute
+    the rule: an aggregate rule does not collapse it and an enumerated rule does not remap
+    it, because no data points are combined (issue #906)."""
 
     @staticmethod
     def _ds(vtype: str) -> dict:
@@ -736,7 +745,7 @@ class TestViralRuleExecutionRowPreserving:
 
     @pytest.mark.parametrize("expr", ["round(DS_1)", "abs(DS_1)", "DS_1 * 2"])
     @pytest.mark.parametrize("use_duckdb", BACKENDS)
-    def test_aggregate_rule_is_dataset_wide(self, expr: str, use_duckdb: bool) -> None:
+    def test_aggregate_rule_copies_per_row(self, expr: str, use_duckdb: bool) -> None:
         result = run(
             script=f"{_AGG_RULE}\nDS_r <- {expr};",
             data_structures={"datasets": [self._ds("Number")]},
@@ -747,11 +756,12 @@ class TestViralRuleExecutionRowPreserving:
             },
             use_duckdb=use_duckdb,
         )
-        # aggregate max over the whole dataset -> 300 on every result row
-        assert list(result["DS_r"].data["VAt_1"]) == [300, 300, 300]
+        # Copied per row (NOT collapsed to the dataset-wide max 300).
+        d = result["DS_r"].data.sort_values("Id_1")
+        assert list(d["VAt_1"]) == [100, 200, 300]
 
     @pytest.mark.parametrize("use_duckdb", BACKENDS)
-    def test_enumerated_rule_is_per_row(self, use_duckdb: bool) -> None:
+    def test_enumerated_rule_copies_per_row(self, use_duckdb: bool) -> None:
         result = run(
             script=f"{_ENUM_RULE}\nDS_r <- round(DS_1);",
             data_structures={"datasets": [self._ds("String")]},
@@ -761,8 +771,8 @@ class TestViralRuleExecutionRowPreserving:
             use_duckdb=use_duckdb,
         )
         df = result["DS_r"].data.sort_values("Id_1")
-        # "A" matches the unary clause -> "Z"; "B" is unmatched -> else "D"
-        assert list(df["VAt_1"]) == ["Z", "D"]
+        # Copied unchanged (NOT remapped "A"->"Z", "B"->"D").
+        assert list(df["VAt_1"]) == ["A", "B"]
 
 
 # -- hierarchy aggregation operator --

--- a/tests/ViralAttributes/test_viral_operators.py
+++ b/tests/ViralAttributes/test_viral_operators.py
@@ -774,6 +774,28 @@ class TestViralRuleExecutionRowPreserving:
         # Copied unchanged (NOT remapped "A"->"Z", "B"->"D").
         assert list(df["VAt_1"]) == ["A", "B"]
 
+    @pytest.mark.parametrize("use_duckdb", BACKENDS)
+    def test_dataset_scalar_binary_copies_and_needs_no_rule(self, use_duckdb: bool) -> None:
+        """A dataset-scalar binary (DS ⊕ scalar) is row-preserving: it copies the viral
+        attribute (an aggregate rule must NOT collapse it) and requires no rule (#906)."""
+        dp = pd.DataFrame({"Id_1": [1, 2, 3], "Me_1": [1.0, 2.0, 3.0], "VAt_1": [100, 200, 300]})
+        # (a) rule present but not executed -> values copied per row (not the dataset-wide max)
+        result = run(
+            script=f"{_AGG_RULE}\nDS_r <- DS_1 + 5;",
+            data_structures={"datasets": [self._ds("Number")]},
+            datapoints={"DS_1": dp},
+            use_duckdb=use_duckdb,
+        )
+        assert list(result["DS_r"].data.sort_values("Id_1")["VAt_1"]) == [100, 200, 300]
+        # (b) no rule at all -> succeeds (no 1-3-3-6), values copied
+        result = run(
+            script="DS_r <- DS_1 + 5;",
+            data_structures={"datasets": [self._ds("Number")]},
+            datapoints={"DS_1": dp},
+            use_duckdb=use_duckdb,
+        )
+        assert list(result["DS_r"].data.sort_values("Id_1")["VAt_1"]) == [100, 200, 300]
+
 
 # -- hierarchy aggregation operator --
 

--- a/tests/ViralAttributes/test_viral_propagation.py
+++ b/tests/ViralAttributes/test_viral_propagation.py
@@ -935,3 +935,62 @@ class TestViralCheckHelpers:
 
     def test_combined_viral_components_empty_for_single_operand(self) -> None:
         assert combined_viral_components([_viral_ds("A", ["VAt_1"])]) == []
+
+
+# -- Row-preserving operators copy viral attributes, they do NOT execute the rule (#906) --
+
+NUM_VA_2ID = {
+    "name": "DS_1",
+    "DataStructure": [
+        {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+        {"name": "Id_2", "type": "String", "role": "Identifier", "nullable": False},
+        {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+        {"name": "VAt_1", "type": "Number", "role": "Viral Attribute", "nullable": True},
+    ],
+}
+
+ENUM_REMAP_RULE = """
+    define viral propagation R (variable VAt_1) is
+        when "A" then "Z";
+        else "F"
+    end viral propagation;
+"""
+
+
+class TestRowPreservingCopiesViral:
+    """A rule may be declared, but a row-preserving operator copies the viral attribute
+    unchanged: an aggregate rule must NOT collapse it and an enumerated rule must NOT
+    remap it, because no data points are combined (issue #906)."""
+
+    def test_unary_aggregate_rule_copies_not_collapses(self) -> None:
+        result = run(
+            script=AGGR_MAX_RULE + "DS_r <- abs(DS_1);",
+            data_structures={"datasets": [NUM_VA_2ID]},
+            datapoints={
+                "DS_1": pd.DataFrame(
+                    {
+                        "Id_1": [1, 1, 2],
+                        "Id_2": ["A", "B", "A"],
+                        "Me_1": [-1.0, -2.0, -3.0],
+                        "VAt_1": [10.0, None, 30.0],
+                    }
+                )
+            },
+        )
+        d = result["DS_r"].data.sort_values(["Id_1", "Id_2"]).reset_index(drop=True)
+        # Copied per row, NOT collapsed to the dataset-wide max (30).
+        assert d["VAt_1"].iloc[0] == 10.0
+        assert pd.isna(d["VAt_1"].iloc[1])
+        assert d["VAt_1"].iloc[2] == 30.0
+
+    def test_scalar_enumerated_rule_copies_not_remaps(self) -> None:
+        result = run(
+            script=ENUM_REMAP_RULE + "DS_r <- DS_1 + 5;",
+            data_structures={"datasets": [DS_1VA]},
+            datapoints={
+                "DS_1": pd.DataFrame({"Id_1": [1, 2], "Me_1": [10.0, 20.0], "VAt_1": ["A", "B"]})
+            },
+        )
+        d = result["DS_r"].data.sort_values("Id_1").reset_index(drop=True)
+        # "A" copied (NOT remapped to "Z"); "B" copied (NOT defaulted to "F").
+        assert list(d["VAt_1"]) == ["A", "B"]

--- a/tests/ViralAttributes/test_viral_propagation.py
+++ b/tests/ViralAttributes/test_viral_propagation.py
@@ -518,6 +518,42 @@ class TestViralRuleCombinesInGroupAndPartition:
         assert list(d[d["Id_1"] == 1]["VAt_1"]) == ["AB", "AB"]
         assert list(d[d["Id_1"] == 2]["VAt_1"]) == ["CD", "CD"]
 
+    @pytest.mark.parametrize(
+        "invocation",
+        ["sum(DS_1 group by Id_1)", "sum(DS_1 over (partition by Id_1))"],
+    )
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_enumerated_rule_applies_to_single_element_group(
+        self, invocation: str, use_duckdb: bool
+    ) -> None:
+        """A group / partition with a single data point still has the enumerated rule
+        applied to it, exactly as a larger group does — the rule runs in every group
+        regardless of size (regression: DuckDB's ``list_reduce`` skipped the lambda for a
+        one-element list, leaving the lone value unmapped, issue #906)."""
+        rule = (
+            "define viral propagation R (variable VAt_1) is\n"
+            '    when "A" then "A1";\n'
+            '    else "F"\n'
+            "end viral propagation;\n"
+        )
+        # group/partition Id_1=1 -> two rows {"A","A"}; Id_1=2 -> a lone {"A"}.
+        dp = pd.DataFrame(
+            {
+                "Id_1": [1, 1, 2],
+                "Id_2": [1, 2, 1],
+                "Me_1": [10.0, 20.0, 30.0],
+                "VAt_1": ["A", "A", "A"],
+            }
+        )
+        result = run(
+            script=rule + f"DS_r <- {invocation};",
+            data_structures={"datasets": [_GP_STR_DS]},
+            datapoints={"DS_1": dp},
+            use_duckdb=use_duckdb,
+        )
+        # Every output row maps "A" -> "A1"; the lone group is NOT copied through as "A".
+        assert set(result["DS_r"].data["VAt_1"]) == {"A1"}
+
 
 # -- Multi-attribute propagation (enumerated + aggregate in one script) --
 

--- a/tests/ViralAttributes/test_viral_propagation.py
+++ b/tests/ViralAttributes/test_viral_propagation.py
@@ -296,85 +296,104 @@ class TestViralPropagationEndToEnd:
         assert pd.isna(va.iloc[2])
 
 
-# -- Every viral attribute requires a rule, even in pure passthrough (issue #877) --
+# -- A viral attribute requires a rule ONLY when it is combined (issue #906) --
 
 
-class TestEveryViralAttributeRequiresRule:
-    """Strict policy: a viral attribute reaching a result without a ``define viral
-    propagation`` rule is a SemanticError (1-3-3-6), even when no combination happens
-    (single-operand assignment, unary, keep, calc). A rule is not optional."""
+class TestViralRuleRequiredOnlyWhenCombined:
+    """Per the VTL 2.2 attribute propagation rule, a rule is required (and executed) only
+    where input data points are combined. A viral attribute merely copied through a
+    row-preserving / single-operand operator needs no rule."""
 
-    def test_identity_assignment_no_rule_raises(self) -> None:
-        """``DS_r <- DS_1`` with a viral attribute and no rule → error."""
-        with pytest.raises(SemanticError) as exc:
-            run(
-                script="DS_r <- DS_1;",
-                data_structures={"datasets": [DS_1VA]},
-                datapoints={"DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0], "VAt_1": ["A"]})},
-            )
-        assert "1-3-3-6" in str(exc.value)
+    # -- non-combining operators: viral attribute copied through, no rule required --
 
-    def test_unary_no_rule_raises(self) -> None:
-        """A unary (row-preserving) operator over a viral attribute with no rule → error."""
-        with pytest.raises(SemanticError) as exc:
-            run(
-                script="DS_r <- abs(DS_1);",
-                data_structures={"datasets": [DS_1VA]},
-                datapoints={"DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [-10.0], "VAt_1": ["A"]})},
-            )
-        assert "1-3-3-6" in str(exc.value)
+    def test_identity_assignment_no_rule_ok(self) -> None:
+        """``DS_r <- DS_1`` copies the viral attribute; no rule needed."""
+        result = run(
+            script="DS_r <- DS_1;",
+            data_structures={"datasets": [DS_1VA]},
+            datapoints={"DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0], "VAt_1": ["A"]})},
+        )
+        assert result["DS_r"].components["VAt_1"].role == Role.VIRAL_ATTRIBUTE
+        assert list(result["DS_r"].data["VAt_1"]) == ["A"]
 
-    def test_keep_no_rule_raises(self) -> None:
-        """A keep clause carries the viral attribute through; without a rule → error."""
-        with pytest.raises(SemanticError) as exc:
-            run(
-                script="DS_r <- DS_1[keep Me_1];",
-                data_structures={"datasets": [DS_1VA]},
-                datapoints={"DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0], "VAt_1": ["A"]})},
-            )
-        assert "1-3-3-6" in str(exc.value)
+    def test_unary_no_rule_ok(self) -> None:
+        """A unary (row-preserving) operator copies the viral attribute; no rule needed."""
+        result = run(
+            script="DS_r <- abs(DS_1);",
+            data_structures={"datasets": [DS_1VA]},
+            datapoints={"DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [-10.0], "VAt_1": ["A"]})},
+        )
+        assert list(result["DS_r"].data["VAt_1"]) == ["A"]
 
-    def test_calc_creates_viral_no_rule_raises(self) -> None:
-        """A calc that creates a viral attribute must also declare a rule for it."""
-        with pytest.raises(SemanticError) as exc:
-            run(
-                script='DS_r <- DS_1[calc viral attribute VAt_1 := "X"];',
-                data_structures={"datasets": [DS_NO_VA]},
-                datapoints={"DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0]})},
-            )
-        assert "1-3-3-6" in str(exc.value)
+    def test_keep_no_rule_ok(self) -> None:
+        """A keep clause carries the viral attribute through unchanged; no rule needed."""
+        result = run(
+            script="DS_r <- DS_1[keep Me_1];",
+            data_structures={"datasets": [DS_1VA]},
+            datapoints={"DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0], "VAt_1": ["A"]})},
+        )
+        assert result["DS_r"].components["VAt_1"].role == Role.VIRAL_ATTRIBUTE
+        assert list(result["DS_r"].data["VAt_1"]) == ["A"]
 
-    def test_partial_rules_missing_one_raises(self) -> None:
-        """Two viral attributes but only one rule → the un-ruled one still errors."""
-        with pytest.raises(SemanticError) as exc:
-            run(
-                script=AGGR_MAX_RULE + "DS_r <- DS_1;",  # rule only for VAt_1
-                data_structures={"datasets": [DS_2VA]},
-                datapoints={
-                    "DS_1": pd.DataFrame(
-                        {"Id_1": [1], "Me_1": [10.0], "VAt_1": ["A"], "VAt_2": [7]}
-                    )
-                },
-            )
-        # VAt_2 has no rule.
-        assert "1-3-3-6" in str(exc.value)
-        assert "VAt_2" in str(exc.value)
+    def test_calc_creates_viral_no_rule_ok(self) -> None:
+        """A calc that creates a viral attribute (never combined) needs no rule."""
+        result = run(
+            script='DS_r <- DS_1[calc viral attribute VAt_1 := "X"];',
+            data_structures={"datasets": [DS_NO_VA]},
+            datapoints={"DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0]})},
+        )
+        assert result["DS_r"].components["VAt_1"].role == Role.VIRAL_ATTRIBUTE
+        assert list(result["DS_r"].data["VAt_1"]) == ["X"]
 
-    def test_semantic_analysis_no_rule_raises(self) -> None:
-        """The rule requirement is enforced at semantic-analysis time (no execution)."""
+    def test_two_viral_partial_rule_passthrough_ok(self) -> None:
+        """Two viral attributes, a rule for only one, pure passthrough → no error
+        (neither is combined)."""
+        result = run(
+            script=AGGR_MAX_RULE + "DS_r <- DS_1;",  # rule only for VAt_1; VAt_2 has none
+            data_structures={"datasets": [DS_2VA]},
+            datapoints={
+                "DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0], "VAt_1": ["A"], "VAt_2": [7]})
+            },
+        )
+        assert set(result["DS_r"].get_viral_attributes_names()) == {"VAt_1", "VAt_2"}
+
+    def test_semantic_analysis_no_rule_ok(self) -> None:
+        """A pure passthrough with no rule passes semantic analysis (no execution)."""
+        result = semantic_analysis(
+            script="DS_r <- DS_1;",
+            data_structures={"datasets": [DS_1VA]},
+        )
+        assert result["DS_r"].components["VAt_1"].role == Role.VIRAL_ATTRIBUTE
+
+    # -- combination points: a rule IS required (SemanticError 1-3-3-6) --
+
+    def test_aggregation_no_rule_raises(self) -> None:
+        """Aggregation combines each group's data points → a rule is required."""
         with pytest.raises(SemanticError) as exc:
             semantic_analysis(
-                script="DS_r <- DS_1;",
+                script="DS_r <- sum(DS_1 group by Id_1);",
+                data_structures={"datasets": [DS_1VA]},
+            )
+        assert "1-3-3-6" in str(exc.value)
+
+    def test_analytic_no_rule_raises(self) -> None:
+        """Analytic combines each partition's data points → a rule is required."""
+        with pytest.raises(SemanticError) as exc:
+            semantic_analysis(
+                script="DS_r <- sum(DS_1 over (partition by Id_1));",
                 data_structures={"datasets": [DS_1VA]},
             )
         assert "1-3-3-6" in str(exc.value)
 
     def test_rule_present_does_not_raise(self) -> None:
-        """Positive control: declaring the rule makes the same script valid."""
+        """Positive control: declaring the rule makes a combining script valid."""
         result = run(
-            script=CONF_RULE + "DS_r <- DS_1;",
-            data_structures={"datasets": [DS_1VA]},
-            datapoints={"DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0], "VAt_1": ["C"]})},
+            script=CONF_RULE + "DS_r <- DS_1 + DS_2;",
+            data_structures=_ds_pair(DS_1VA),
+            datapoints={
+                "DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0], "VAt_1": ["C"]}),
+                "DS_2": pd.DataFrame({"Id_1": [1], "Me_1": [5.0], "VAt_1": ["N"]}),
+            },
         )
         assert result["DS_r"].components["VAt_1"].role == Role.VIRAL_ATTRIBUTE
 

--- a/tests/ViralAttributes/test_viral_propagation.py
+++ b/tests/ViralAttributes/test_viral_propagation.py
@@ -7,8 +7,16 @@ import pytest
 
 from vtlengine import run, semantic_analysis
 from vtlengine.API import create_ast
+from vtlengine.DataTypes import Integer, String
 from vtlengine.Exceptions import SemanticError, VTLSyntaxError
-from vtlengine.Model import Role
+from vtlengine.Model import Component, Dataset, Role
+from vtlengine.ViralPropagation import (
+    ViralPropagationRegistry,
+    ViralPropagationRule,
+    combined_viral_components,
+    require_rules,
+    set_current_registry,
+)
 
 # -- Shared propagation rules --
 
@@ -863,3 +871,48 @@ class TestKeepPreservesViralAttributes:
         # (null, "Z") -> "F" (else), not the leaked "Z".
         assert ds.data["VAt_1"].iloc[0] == "F"
         assert ds.data["At_1"].iloc[0] == "y"
+
+
+# -- Unit tests for the combination-point check helpers --
+
+
+def _viral_ds(name: str, viral_names: list) -> Dataset:
+    comps = {"Id_1": Component("Id_1", Integer, Role.IDENTIFIER, False)}
+    for v in viral_names:
+        comps[v] = Component(v, String, Role.VIRAL_ATTRIBUTE, True)
+    return Dataset(name=name, components=comps, data=None)
+
+
+class TestViralCheckHelpers:
+    """``require_rules`` / ``combined_viral_components`` back the combination-point check."""
+
+    def test_require_rules_raises_when_missing(self) -> None:
+        set_current_registry(ViralPropagationRegistry())
+        comp = Component("VAt_1", String, Role.VIRAL_ATTRIBUTE, True)
+        with pytest.raises(SemanticError) as exc:
+            require_rules([comp])
+        assert "1-3-3-6" in str(exc.value)
+
+    def test_require_rules_passes_when_present(self) -> None:
+        registry = ViralPropagationRegistry()
+        registry.register(
+            ViralPropagationRule(
+                name="VAt_1",
+                signature_type="variable",
+                target="VAt_1",
+                enumerated_clauses=[],
+                aggregate_function="max",
+            )
+        )
+        set_current_registry(registry)
+        require_rules([Component("VAt_1", String, Role.VIRAL_ATTRIBUTE, True)])  # must not raise
+
+    def test_combined_viral_components_only_shared(self) -> None:
+        # VAt_1 is viral in both operands (combined); VAt_2 only in one (copied, no rule needed).
+        combined = combined_viral_components(
+            [_viral_ds("A", ["VAt_1", "VAt_2"]), _viral_ds("B", ["VAt_1"])]
+        )
+        assert {c.name for c in combined} == {"VAt_1"}
+
+    def test_combined_viral_components_empty_for_single_operand(self) -> None:
+        assert combined_viral_components([_viral_ds("A", ["VAt_1"])]) == []

--- a/tests/ViralAttributes/test_viral_propagation.py
+++ b/tests/ViralAttributes/test_viral_propagation.py
@@ -306,10 +306,10 @@ class TestViralRuleRequiredOnlyWhenCombined:
 
     # -- non-combining operators: viral attribute copied through, no rule required --
 
-    def test_identity_assignment_no_rule_ok(self) -> None:
-        """``DS_r <- DS_1`` copies the viral attribute; no rule needed."""
+    def test_calc_measure_no_rule_ok(self) -> None:
+        """A calc clause is row-preserving: it copies the viral attribute; no rule needed."""
         result = run(
-            script="DS_r <- DS_1;",
+            script="DS_r <- DS_1[calc Me_2 := Me_1 * 2];",
             data_structures={"datasets": [DS_1VA]},
             datapoints={"DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0], "VAt_1": ["A"]})},
         )
@@ -345,11 +345,11 @@ class TestViralRuleRequiredOnlyWhenCombined:
         assert result["DS_r"].components["VAt_1"].role == Role.VIRAL_ATTRIBUTE
         assert list(result["DS_r"].data["VAt_1"]) == ["X"]
 
-    def test_two_viral_partial_rule_passthrough_ok(self) -> None:
-        """Two viral attributes, a rule for only one, pure passthrough → no error
-        (neither is combined)."""
+    def test_two_viral_partial_rule_row_preserving_ok(self) -> None:
+        """Two viral attributes, a rule for only one, through a row-preserving operator →
+        no error (neither is combined, so even the un-ruled VAt_2 is fine)."""
         result = run(
-            script=AGGR_MAX_RULE + "DS_r <- DS_1;",  # rule only for VAt_1; VAt_2 has none
+            script=AGGR_MAX_RULE + "DS_r <- abs(DS_1);",  # rule only for VAt_1; VAt_2 has none
             data_structures={"datasets": [DS_2VA]},
             datapoints={
                 "DS_1": pd.DataFrame({"Id_1": [1], "Me_1": [10.0], "VAt_1": ["A"], "VAt_2": [7]})
@@ -358,9 +358,9 @@ class TestViralRuleRequiredOnlyWhenCombined:
         assert set(result["DS_r"].get_viral_attributes_names()) == {"VAt_1", "VAt_2"}
 
     def test_semantic_analysis_no_rule_ok(self) -> None:
-        """A pure passthrough with no rule passes semantic analysis (no execution)."""
+        """A row-preserving op with no rule passes semantic analysis (no execution)."""
         result = semantic_analysis(
-            script="DS_r <- DS_1;",
+            script="DS_r <- DS_1 * 2;",
             data_structures={"datasets": [DS_1VA]},
         )
         assert result["DS_r"].components["VAt_1"].role == Role.VIRAL_ATTRIBUTE
@@ -396,6 +396,127 @@ class TestViralRuleRequiredOnlyWhenCombined:
             },
         )
         assert result["DS_r"].components["VAt_1"].role == Role.VIRAL_ATTRIBUTE
+
+
+# -- The rule COMBINES per group / partition at aggregation & analytic (issue #906) --
+
+# Two identifiers; group/partition Id_1=1 -> {10, null, 30}; Id_1=2 -> {5}.
+_GP_NUM_DS = {
+    "name": "DS_1",
+    "DataStructure": [
+        {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+        {"name": "Id_2", "type": "Integer", "role": "Identifier", "nullable": False},
+        {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+        {"name": "VAt_1", "type": "Number", "role": "Viral Attribute", "nullable": True},
+    ],
+}
+_GP_STR_DS = {
+    **_GP_NUM_DS,
+    "DataStructure": [
+        *_GP_NUM_DS["DataStructure"][:3],
+        {"name": "VAt_1", "type": "String", "role": "Viral Attribute", "nullable": True},
+    ],
+}
+
+_ENUM_PAIR_RULE = """
+    define viral propagation R (variable VAt_1) is
+        when "A" and "B" then "AB";
+        when "C" and "D" then "CD";
+        else "F"
+    end viral propagation;
+"""
+
+
+def _gp_num_dp() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Id_1": [1, 1, 1, 2],
+            "Id_2": [1, 2, 3, 1],
+            "Me_1": [10.0, 20.0, 30.0, 40.0],
+            "VAt_1": [10.0, None, 30.0, 5.0],
+        }
+    )
+
+
+def _gp_str_dp() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Id_1": [1, 1, 2, 2],
+            "Id_2": [1, 2, 1, 2],
+            "Me_1": [10.0, 20.0, 30.0, 40.0],
+            "VAt_1": ["A", "B", "C", "D"],
+        }
+    )
+
+
+class TestViralRuleCombinesInGroupAndPartition:
+    """At the aggregation and analytic combination points the propagation rule is executed
+    within each group / partition (issue #906): an aggregate rule combines the group's
+    values (skipping nulls), analytic broadcasts the combined value to every row of the
+    partition, and an enumerated rule combines the group's values through its clauses."""
+
+    @pytest.mark.parametrize(
+        "agg_fn, group1",
+        # group Id_1=1 = {10, null, 30}; nulls are skipped: min 10, max 30, sum 40, avg 20.
+        [("min", 10.0), ("max", 30.0), ("sum", 40.0), ("avg", 20.0)],
+    )
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_aggregate_rule_combines_per_group_skipping_nulls(
+        self, agg_fn: str, group1: float, use_duckdb: bool
+    ) -> None:
+        rule = (
+            f"define viral propagation S (variable VAt_1) is\n"
+            f"    aggregate {agg_fn}\n"
+            f"end viral propagation;\n"
+        )
+        result = run(
+            script=rule + "DS_r <- sum(DS_1 group by Id_1);",
+            data_structures={"datasets": [_GP_NUM_DS]},
+            datapoints={"DS_1": _gp_num_dp()},
+            use_duckdb=use_duckdb,
+        )
+        d = result["DS_r"].data.sort_values("Id_1").reset_index(drop=True)
+        # One combined value per group; group Id_1=2 keeps its lone value 5.
+        assert d["VAt_1"].iloc[0] == group1
+        assert d["VAt_1"].iloc[1] == 5.0
+
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_analytic_rule_combines_per_partition_and_broadcasts(self, use_duckdb: bool) -> None:
+        result = run(
+            script=AGGR_MAX_RULE + "DS_r <- sum(DS_1 over (partition by Id_1));",
+            data_structures={"datasets": [_GP_NUM_DS]},
+            datapoints={"DS_1": _gp_num_dp()},
+            use_duckdb=use_duckdb,
+        )
+        d = result["DS_r"].data.sort_values(["Id_1", "Id_2"]).reset_index(drop=True)
+        # max over partition Id_1=1 {10, null, 30} = 30, broadcast to all 3 rows; partition 2 = 5.
+        assert list(d[d["Id_1"] == 1]["VAt_1"]) == [30.0, 30.0, 30.0]
+        assert list(d[d["Id_1"] == 2]["VAt_1"]) == [5.0]
+
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_enumerated_rule_combines_per_group(self, use_duckdb: bool) -> None:
+        result = run(
+            script=_ENUM_PAIR_RULE + "DS_r <- sum(DS_1 group by Id_1);",
+            data_structures={"datasets": [_GP_STR_DS]},
+            datapoints={"DS_1": _gp_str_dp()},
+            use_duckdb=use_duckdb,
+        )
+        d = result["DS_r"].data.sort_values("Id_1").reset_index(drop=True)
+        # group {"A","B"} matches the binary clause -> "AB"; group {"C","D"} -> "CD".
+        assert list(d["VAt_1"]) == ["AB", "CD"]
+
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_enumerated_rule_combines_per_partition(self, use_duckdb: bool) -> None:
+        result = run(
+            script=_ENUM_PAIR_RULE + "DS_r <- sum(DS_1 over (partition by Id_1));",
+            data_structures={"datasets": [_GP_STR_DS]},
+            datapoints={"DS_1": _gp_str_dp()},
+            use_duckdb=use_duckdb,
+        )
+        d = result["DS_r"].data.sort_values(["Id_1", "Id_2"]).reset_index(drop=True)
+        # Combined per partition and broadcast to each row.
+        assert list(d[d["Id_1"] == 1]["VAt_1"]) == ["AB", "AB"]
+        assert list(d[d["Id_1"] == 2]["VAt_1"]) == ["CD", "CD"]
 
 
 # -- Multi-attribute propagation (enumerated + aggregate in one script) --


### PR DESCRIPTION
## Summary

Viral attribute propagation was executed (and required) on essentially every dataset operator via shared row-preserving hooks in both backends, contrary to the VTL 2.2 *Attribute propagation rule*, which runs the default propagation algorithm **only when input data points are combined** and otherwise **copies** viral attributes unchanged.

This restricts propagation to the three combination points and copies everywhere else:

- **Combination points** (rule executed, rule required): an operation over two or more datasets (dataset–dataset binary, joins, `if`/`case` with ≥2 dataset branches); an aggregation/analytic group-by/partition; and the `hierarchy` roll-up.
- **Everywhere else** (viral copied unchanged, no rule required): unary ops, dataset⊕scalar, `calc`/`keep`/`drop`/`rename`/`unpivot`, `cast`, time shifts, `nvl`, set operators, `check_datapoint`/`check_hierarchy`.

The `SemanticError 1-3-3-6` (a viral attribute needs a `define viral propagation` rule) moves from a global per-statement check into the combining operators' `validate` methods — so it still fires during `semantic_analysis()` on both backends — and now flags only the viral attributes that are actually combined.

Fixes #906.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — both backends (`VTL_ENGINE_BACKEND=duckdb` default: 5357 passed; `=pandas`: 4785 passed)
- [x] Documentation updated (error `1-3-3-6` description; `error_messages.rst` regenerates from `messages.py`)

## Impact / Risk

- **Behavior change.** Row-preserving operators no longer execute the rule: an aggregate rule no longer collapses a viral column dataset-wide (e.g. `abs(DS_1)` with `aggregate max`), and an enumerated rule no longer remaps values — both now copy. A viral attribute that is never combined no longer requires a rule (previously raised `1-3-3-6`). A rule is still required, and `1-3-3-6` still raised, when a viral attribute **is** combined at one of the three points.
- **Both backends** (pandas + DuckDB transpiler) updated in parity; verified to produce identical results.
- No public API changes. No SDMX compatibility concerns.

## Notes

- Follow-up: a DuckDB-only adaptation for `main` will be produced separately — `main` has diverged (it is DuckDB-only and does not yet have #878), and the adaptation must reconcile with #897's `check_datapoint` viral behavior.
