### PR TITLE
Fix #910: viral sum/avg type check at combination points, avg promotes to Number

### DIFF
--- a/src/vtlengine/Interpreter/__init__.py
+++ b/src/vtlengine/Interpreter/__init__.py
@@ -462,30 +462,18 @@ class InterpreterAnalyzer(ASTTemplate):
         )
         registry.register(rule)
 
-        # sum/avg require a numeric viral attribute; raise a clear error at semantic time
-        # instead of a cryptic runtime crash (issue #877).
-        if aggregate_function in ("sum", "avg"):
-            incompatible: Optional[Type[ScalarType]] = None
-            if node.signature_type == "variable":
-                for ds in (self.datasets or {}).values():
-                    comp = ds.components.get(node.target)
-                    if (
-                        comp is not None
-                        and comp.role == Role.VIRAL_ATTRIBUTE
-                        and comp.data_type not in (Integer, Number)
-                    ):
-                        incompatible = comp.data_type
-                        break
-            else:  # valuedomain
-                vd = (self.value_domains or {}).get(node.target)
-                if vd is not None and vd.type not in (Integer, Number):
-                    incompatible = vd.type
-            if incompatible is not None:
+        # sum/avg on a value-domain rule is checked at definition time: the value
+        # domain's type is intrinsic to the rule target. Variable rules are checked in
+        # require_rules, where the rule is actually applied — a non-numeric viral
+        # attribute that is never combined must not raise (issue #910).
+        if aggregate_function in ("sum", "avg") and node.signature_type == "valuedomain":
+            vd = (self.value_domains or {}).get(node.target)
+            if vd is not None and vd.type not in (Integer, Number):
                 raise SemanticError(
                     "1-3-3-5",
                     name=node.target,
                     function=aggregate_function,
-                    type=incompatible.__name__,
+                    type=vd.type.__name__,
                 )
 
     # Execution Language

--- a/src/vtlengine/Operators/Aggregation.py
+++ b/src/vtlengine/Operators/Aggregation.py
@@ -35,7 +35,11 @@ from vtlengine.DataTypes.TimeHandling import (
 )
 from vtlengine.Exceptions import RunTimeError, SemanticError
 from vtlengine.Model import Component, Dataset, Role
-from vtlengine.ViralPropagation import get_current_registry, require_rules
+from vtlengine.ViralPropagation import (
+    apply_viral_return_types,
+    get_current_registry,
+    require_rules,
+)
 
 
 def extract_grouping_identifiers(
@@ -173,7 +177,9 @@ class Aggregation(Operator.Unary):
 
         # Aggregation combines the data points of each group, so the surviving viral
         # attributes are combined and require a propagation rule (issue #906).
-        require_rules(operand.get_viral_attributes())
+        viral_attributes = operand.get_viral_attributes()
+        require_rules(viral_attributes)
+        apply_viral_return_types(viral_attributes, result_components)
         # VDS is handled in visit_Aggregation
         return Dataset(name="result", components=result_components, data=None)
 

--- a/src/vtlengine/Operators/Analytic.py
+++ b/src/vtlengine/Operators/Analytic.py
@@ -40,7 +40,11 @@ from vtlengine.DataTypes import (
 from vtlengine.Exceptions import RunTimeError, SemanticError
 from vtlengine.Model import Component, Dataset, Role
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
-from vtlengine.ViralPropagation import get_current_registry, require_rules
+from vtlengine.ViralPropagation import (
+    apply_viral_return_types,
+    get_current_registry,
+    require_rules,
+)
 
 return_integer_operators = [MAX, MIN, SUM]
 
@@ -212,7 +216,9 @@ class Analytic(Operator.Unary):
         dataset_name = VirtualCounter._new_ds_name()
         # Analytic combines the data points within each partition, so the surviving viral
         # attributes are combined and require a propagation rule (issue #906).
-        require_rules(operand.get_viral_attributes())
+        viral_attributes = operand.get_viral_attributes()
+        require_rules(viral_attributes)
+        apply_viral_return_types(viral_attributes, result_components)
         return Dataset(name=dataset_name, components=result_components, data=None)
 
     @classmethod

--- a/src/vtlengine/Operators/Conditional.py
+++ b/src/vtlengine/Operators/Conditional.py
@@ -14,6 +14,7 @@ from vtlengine.Model import DataComponent, Dataset, Role, Scalar
 from vtlengine.Operators import Binary, Operator
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
 from vtlengine.ViralPropagation import (
+    apply_viral_return_types,
     combined_viral_components,
     get_current_registry,
     require_rules,
@@ -243,9 +244,9 @@ class If(Operator):
         result_components = {comp_name: copy(comp) for comp_name, comp in left.components.items()}
         # if-then-else over two datasets combines their data points per row, so viral
         # attributes carried by both branches require a propagation rule (issue #906).
-        require_rules(
-            combined_viral_components([b for b in (left, right) if isinstance(b, Dataset)])
-        )
+        combined = combined_viral_components([b for b in (left, right) if isinstance(b, Dataset)])
+        require_rules(combined)
+        apply_viral_return_types(combined, result_components)
         return Dataset(name=dataset_name, components=result_components, data=None)
 
 
@@ -472,7 +473,9 @@ class Case(Operator):
         if Dataset not in then_else_types:
             raise SemanticError("2-1-9-6", op=cls.op)
 
-        components = next(op for op in ops if isinstance(op, Dataset)).components
+        # Rebuild the dict: the result must never share it with the branch dataset, as
+        # apply_viral_return_types may replace entries in it.
+        components = dict(next(op for op in ops if isinstance(op, Dataset)).components)
         comp_names = [comp.name for comp in components.values()]
         for op in ops:
             if isinstance(op, Dataset) and op.get_components_names() != comp_names:
@@ -480,5 +483,7 @@ class Case(Operator):
 
         # case over two or more datasets combines their data points, so viral attributes
         # carried by two or more branches require a propagation rule (issue #906).
-        require_rules(combined_viral_components([op for op in ops if isinstance(op, Dataset)]))
+        combined = combined_viral_components([op for op in ops if isinstance(op, Dataset)])
+        require_rules(combined)
+        apply_viral_return_types(combined, components)
         return Dataset(name=dataset_name, components=components, data=None)

--- a/src/vtlengine/Operators/HROperators.py
+++ b/src/vtlengine/Operators/HROperators.py
@@ -15,7 +15,11 @@ from vtlengine.Utils._number_config import (
     numbers_are_greater_equal,
     numbers_are_less_equal,
 )
-from vtlengine.ViralPropagation import get_current_registry, require_rules
+from vtlengine.ViralPropagation import (
+    apply_viral_return_types,
+    get_current_registry,
+    require_rules,
+)
 
 REMOVE = "REMOVE_VALUE"
 
@@ -261,6 +265,7 @@ class Hierarchy(Operators.Operator):
         # The roll-up combines child nodes into each computed node, so the combined viral
         # attributes require a propagation rule (issue #906).
         require_rules(viral_components or [])
+        apply_viral_return_types(viral_components or [], result_components)
         return Dataset(name=dataset_name, components=result_components, data=None)
 
     @staticmethod

--- a/src/vtlengine/Operators/Join.py
+++ b/src/vtlengine/Operators/Join.py
@@ -11,7 +11,11 @@ from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import Component, Dataset, Role
 from vtlengine.Operators import Operator, _id_type_promotion_join_keys
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
-from vtlengine.ViralPropagation import get_current_registry, require_rules
+from vtlengine.ViralPropagation import (
+    apply_viral_return_types,
+    get_current_registry,
+    require_rules,
+)
 
 
 def merged_viral_attribute_names(
@@ -155,6 +159,7 @@ class Join(Operator):
                         component.data_type = data_type
                     merged_components[component_name] = component
 
+        apply_viral_return_types(merged_viral_comps.values(), merged_components)
         return merged_components
 
     @classmethod

--- a/src/vtlengine/Operators/__init__.py
+++ b/src/vtlengine/Operators/__init__.py
@@ -35,6 +35,7 @@ from vtlengine.Exceptions import SemanticError
 from vtlengine.Model import Component, DataComponent, Dataset, Role, Scalar, ScalarSet
 from vtlengine.Utils.__Virtual_Assets import VirtualCounter
 from vtlengine.ViralPropagation import (
+    apply_viral_return_types,
     combined_viral_components,
     get_current_registry,
     require_rules,
@@ -358,7 +359,9 @@ class Binary(Operator):
         # Viral attributes present in BOTH operands have their data points merged, so they
         # are combined and require a propagation rule; a viral attribute in a single operand
         # is copied through and needs none (issue #906).
-        require_rules(combined_viral_components([left_operand, right_operand]))
+        combined = combined_viral_components([left_operand, right_operand])
+        require_rules(combined)
+        apply_viral_return_types(combined, result_components)
 
         result_dataset = Dataset(name=dataset_name, components=result_components, data=None)
         cls.apply_return_type_dataset(result_dataset, left_operand, right_operand)

--- a/src/vtlengine/ViralPropagation/__init__.py
+++ b/src/vtlengine/ViralPropagation/__init__.py
@@ -7,11 +7,15 @@ Registry for viral attribute propagation rules as defined by the VTL 2.2
 in :mod:`vtlengine.ViralPropagation.sql`.
 """
 
+from copy import copy
 from dataclasses import dataclass, field
 from functools import reduce
 from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
+
+from vtlengine.DataTypes import Integer, Number
+from vtlengine.Exceptions import SemanticError
 
 
 @dataclass
@@ -188,9 +192,6 @@ def require_rules(components: Iterable[Any]) -> None:
     non-numeric viral attribute: the check runs only where the rule actually executes,
     so a non-numeric attribute that is never combined raises nothing (issue #910).
     """
-    from vtlengine.DataTypes import Integer, Number  # local imports avoid an import cycle
-    from vtlengine.Exceptions import SemanticError
-
     registry = get_current_registry()
     for comp in components:
         rule = registry.rule_for(comp)
@@ -216,10 +217,6 @@ def apply_viral_return_types(components: Iterable[Any], result_components: Dict[
     Call this right after :func:`require_rules` at every combination point, with the
     same combined components and the result-components mapping under construction.
     """
-    from copy import copy
-
-    from vtlengine.DataTypes import Number  # local import avoids an import cycle
-
     registry = get_current_registry()
     for comp in components:
         rule = registry.rule_for(comp)

--- a/src/vtlengine/ViralPropagation/__init__.py
+++ b/src/vtlengine/ViralPropagation/__init__.py
@@ -223,7 +223,7 @@ def apply_viral_return_types(components: Iterable[Any], result_components: Dict[
         if rule is None or rule.aggregate_function != "avg":
             continue
         result_comp = result_components.get(comp.name)
-        if result_comp is None or result_comp.data_type == Number:
+        if result_comp is None:
             continue
         promoted = copy(result_comp)
         promoted.data_type = Number

--- a/src/vtlengine/ViralPropagation/__init__.py
+++ b/src/vtlengine/ViralPropagation/__init__.py
@@ -183,13 +183,54 @@ def require_rules(components: Iterable[Any]) -> None:
     rule (an operation over two or more datasets, an aggregation/analytic group-by, or
     a hierarchy roll-up), where the default propagation algorithm must be executed. A
     viral attribute that is only copied through (row-preserving operators) needs no rule.
+
+    Also raises SemanticError 1-3-3-5 when a ``sum``/``avg`` rule applies to a
+    non-numeric viral attribute: the check runs only where the rule actually executes,
+    so a non-numeric attribute that is never combined raises nothing (issue #910).
     """
-    from vtlengine.Exceptions import SemanticError  # local import avoids an import cycle
+    from vtlengine.DataTypes import Integer, Number  # local imports avoid an import cycle
+    from vtlengine.Exceptions import SemanticError
 
     registry = get_current_registry()
     for comp in components:
-        if registry.rule_for(comp) is None:
+        rule = registry.rule_for(comp)
+        if rule is None:
             raise SemanticError("1-3-3-6", name=comp.name)
+        if rule.aggregate_function in ("sum", "avg") and comp.data_type not in (Integer, Number):
+            raise SemanticError(
+                "1-3-3-5",
+                name=comp.name,
+                function=rule.aggregate_function,
+                type=comp.data_type.__name__,
+            )
+
+
+def apply_viral_return_types(components: Iterable[Any], result_components: Dict[str, Any]) -> None:
+    """Set the result data type of viral attributes combined under an ``avg`` rule to
+    Number: avg yields fractional values, mirroring the Avg operator's return type.
+    min/max/sum and enumerated rules keep the input type (sum mirrors Sum, which has no
+    return type). Promoted entries are always replaced with a copy, because some
+    operators share the result component objects (or the dict itself) with their input
+    datasets and the input structure must never be mutated.
+
+    Call this right after :func:`require_rules` at every combination point, with the
+    same combined components and the result-components mapping under construction.
+    """
+    from copy import copy
+
+    from vtlengine.DataTypes import Number  # local import avoids an import cycle
+
+    registry = get_current_registry()
+    for comp in components:
+        rule = registry.rule_for(comp)
+        if rule is None or rule.aggregate_function != "avg":
+            continue
+        result_comp = result_components.get(comp.name)
+        if result_comp is None or result_comp.data_type == Number:
+            continue
+        promoted = copy(result_comp)
+        promoted.data_type = Number
+        result_components[comp.name] = promoted
 
 
 def combined_viral_components(operands: Iterable[Any]) -> List[Any]:

--- a/tests/ViralAttributes/test_viral_operators.py
+++ b/tests/ViralAttributes/test_viral_operators.py
@@ -907,7 +907,9 @@ class TestViralAttributeCheckHierarchy:
 
 class TestViralAggregateRuleTypeValidation:
     """`aggregate sum`/`avg` require a numeric viral attribute; a clear SemanticError
-    (1-3-3-5) must be raised at semantic analysis time, not a runtime crash."""
+    (1-3-3-5) must be raised at semantic analysis time, not a runtime crash. The check
+    runs where the rule is actually applied (a combination point), so a non-numeric
+    viral attribute that is never combined raises nothing (issue #910)."""
 
     @staticmethod
     def _ds(vtype: str) -> dict:
@@ -936,14 +938,35 @@ class TestViralAggregateRuleTypeValidation:
 
     @pytest.mark.parametrize("fn", ["sum", "avg"])
     @pytest.mark.parametrize("vtype", ["String", "Date", "Boolean"])
-    def test_sum_avg_non_numeric_raises(self, fn: str, vtype: str) -> None:
+    @pytest.mark.parametrize(
+        "combination",
+        ["DS_r <- DS_1 + DS_1;", "DS_r <- sum(DS_1 group by Id_1);"],
+    )
+    def test_sum_avg_non_numeric_raises_at_combination(
+        self, fn: str, vtype: str, combination: str
+    ) -> None:
         script = (
             f"define viral propagation VP (variable VAt_1) is aggregate {fn} "
-            "end viral propagation;\nDS_r <- DS_1 * 2;"
+            f"end viral propagation;\n{combination}"
         )
         with pytest.raises(SemanticError) as exc:
             semantic_analysis(script=script, data_structures=self._ds(vtype))
         assert "1-3-3-5" in str(exc.value)
+
+    @pytest.mark.parametrize("fn", ["sum", "avg"])
+    @pytest.mark.parametrize("vtype", ["String", "Date", "Boolean"])
+    def test_row_preserving_only_no_error(self, fn: str, vtype: str) -> None:
+        """The rule never executes (no combination point), so no type error is raised —
+        not for the row-preserving usage of DS_1 and not for a dataset the script never
+        references (issue #910)."""
+        structures = self._ds(vtype)
+        structures["datasets"].append({**structures["datasets"][0], "name": "DS_9"})
+        script = (
+            f"define viral propagation VP (variable VAt_1) is aggregate {fn} "
+            "end viral propagation;\nDS_r <- DS_1 * 2;"
+        )
+        # Must not raise.
+        semantic_analysis(script=script, data_structures=structures)
 
     @pytest.mark.parametrize(
         "fn,vtype",
@@ -952,7 +975,7 @@ class TestViralAggregateRuleTypeValidation:
     def test_valid_combinations_pass(self, fn: str, vtype: str) -> None:
         script = (
             f"define viral propagation VP (variable VAt_1) is aggregate {fn} "
-            "end viral propagation;\nDS_r <- DS_1 * 2;"
+            "end viral propagation;\nDS_r <- DS_1 + DS_1;"
         )
         # Must not raise.
         semantic_analysis(script=script, data_structures=self._ds(vtype))

--- a/tests/ViralAttributes/test_viral_propagation.py
+++ b/tests/ViralAttributes/test_viral_propagation.py
@@ -7,12 +7,13 @@ import pytest
 
 from vtlengine import run, semantic_analysis
 from vtlengine.API import create_ast
-from vtlengine.DataTypes import Integer, String
+from vtlengine.DataTypes import Integer, Number, String
 from vtlengine.Exceptions import SemanticError, VTLSyntaxError
 from vtlengine.Model import Component, Dataset, Role
 from vtlengine.ViralPropagation import (
     ViralPropagationRegistry,
     ViralPropagationRule,
+    apply_viral_return_types,
     combined_viral_components,
     require_rules,
     set_current_registry,
@@ -1049,6 +1050,162 @@ class TestKeepPreservesViralAttributes:
         assert ds.data["At_1"].iloc[0] == "y"
 
 
+# -- avg promotes a combined Integer viral attribute to Number (issue #910) --
+
+_AVG_RULE = (
+    "define viral propagation AV (variable VAt_1) is\n    aggregate avg\nend viral propagation;\n"
+)
+
+_SUM_RULE = (
+    "define viral propagation SM (variable VAt_1) is\n    aggregate sum\nend viral propagation;\n"
+)
+
+_INT_VA_DS = {
+    "name": "DS_1",
+    "DataStructure": [
+        {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+        {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+        {"name": "VAt_1", "type": "Integer", "role": "Viral Attribute", "nullable": True},
+    ],
+}
+
+_INT_VA_2ID_DS = {
+    "name": "DS_1",
+    "DataStructure": [
+        {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+        {"name": "Id_2", "type": "Integer", "role": "Identifier", "nullable": False},
+        {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+        {"name": "VAt_1", "type": "Integer", "role": "Viral Attribute", "nullable": True},
+    ],
+}
+
+
+def _int_va_dp() -> dict:
+    return {
+        "DS_1": pd.DataFrame({"Id_1": [1, 2], "Me_1": [10.0, 20.0], "VAt_1": [1, 2]}),
+        "DS_2": pd.DataFrame({"Id_1": [1, 2], "Me_1": [5.0, 15.0], "VAt_1": [2, 3]}),
+    }
+
+
+def _int_va_2id_dp() -> dict:
+    return {
+        "DS_1": pd.DataFrame(
+            {
+                "Id_1": [1, 1, 2],
+                "Id_2": [1, 2, 1],
+                "Me_1": [10.0, 20.0, 30.0],
+                "VAt_1": [1, 2, 5],
+            }
+        )
+    }
+
+
+class TestAvgRulePromotesIntegerViral:
+    """An `aggregate avg` rule yields fractional values, so a combined Integer viral
+    attribute is promoted to Number in the result — mirroring the Avg operator's
+    return type; `sum` keeps the input type, mirroring Sum (issue #910)."""
+
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_avg_binary_promotes_to_number(self, use_duckdb: bool) -> None:
+        result = run(
+            script=_AVG_RULE + "DS_r <- DS_1 + DS_2;",
+            data_structures=_ds_pair(_INT_VA_DS),
+            datapoints=_int_va_dp(),
+            use_duckdb=use_duckdb,
+        )
+        ds_r = result["DS_r"]
+        assert ds_r.components["VAt_1"].data_type == Number
+        d = ds_r.data.sort_values("Id_1").reset_index(drop=True)
+        assert list(d["VAt_1"]) == [1.5, 2.5]
+
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_avg_join_promotes_to_number(self, use_duckdb: bool) -> None:
+        # Distinct measure names per operand: a shared non-identifier would be ambiguous.
+        ds_2 = {
+            "name": "DS_2",
+            "DataStructure": [
+                {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+                {"name": "Me_2", "type": "Number", "role": "Measure", "nullable": True},
+                {"name": "VAt_1", "type": "Integer", "role": "Viral Attribute", "nullable": True},
+            ],
+        }
+        result = run(
+            script=_AVG_RULE + "DS_r <- inner_join(DS_1, DS_2);",
+            data_structures={"datasets": [_INT_VA_DS, ds_2]},
+            datapoints={
+                "DS_1": pd.DataFrame({"Id_1": [1, 2], "Me_1": [10.0, 20.0], "VAt_1": [1, 2]}),
+                "DS_2": pd.DataFrame({"Id_1": [1, 2], "Me_2": [5.0, 15.0], "VAt_1": [2, 3]}),
+            },
+            use_duckdb=use_duckdb,
+        )
+        ds_r = result["DS_r"]
+        assert ds_r.components["VAt_1"].data_type == Number
+        d = ds_r.data.sort_values("Id_1").reset_index(drop=True)
+        assert list(d["VAt_1"]) == [1.5, 2.5]
+
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_avg_aggregation_promotes_to_number(self, use_duckdb: bool) -> None:
+        result = run(
+            script=_AVG_RULE + "DS_r <- sum(DS_1 group by Id_1);",
+            data_structures={"datasets": [_INT_VA_2ID_DS]},
+            datapoints=_int_va_2id_dp(),
+            use_duckdb=use_duckdb,
+        )
+        ds_r = result["DS_r"]
+        assert ds_r.components["VAt_1"].data_type == Number
+        d = ds_r.data.sort_values("Id_1").reset_index(drop=True)
+        # group Id_1=1 avg(1, 2) = 1.5; group Id_1=2 keeps its lone value 5.
+        assert list(d["VAt_1"]) == [1.5, 5.0]
+
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_avg_analytic_promotes_and_input_untouched(self, use_duckdb: bool) -> None:
+        result = run(
+            script=_AVG_RULE + "DS_r <- sum(DS_1 over (partition by Id_1)); DS_r2 <- DS_1;",
+            data_structures={"datasets": [_INT_VA_2ID_DS]},
+            datapoints=_int_va_2id_dp(),
+            use_duckdb=use_duckdb,
+        )
+        ds_r = result["DS_r"]
+        assert ds_r.components["VAt_1"].data_type == Number
+        d = ds_r.data.sort_values(["Id_1", "Id_2"]).reset_index(drop=True)
+        # avg over partition Id_1=1 {1, 2} = 1.5, broadcast; partition Id_1=2 keeps 5.
+        assert list(d[d["Id_1"] == 1]["VAt_1"]) == [1.5, 1.5]
+        assert list(d[d["Id_1"] == 2]["VAt_1"]) == [5.0]
+        # The analytic result shares component objects with its input: the promotion
+        # must not leak into the input dataset structure (DS_r2 copies DS_1).
+        assert result["DS_r2"].components["VAt_1"].data_type == Integer
+
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_avg_case_promotes_and_input_untouched(self, use_duckdb: bool) -> None:
+        result = run(
+            script=_AVG_RULE
+            + "DS_r <- case when DS_1#Me_1 > 12.0 then DS_1 else DS_2; DS_r2 <- DS_1;",
+            data_structures=_ds_pair(_INT_VA_DS),
+            datapoints=_int_va_dp(),
+            use_duckdb=use_duckdb,
+        )
+        ds_r = result["DS_r"]
+        assert ds_r.components["VAt_1"].data_type == Number
+        d = ds_r.data.sort_values("Id_1").reset_index(drop=True)
+        # Viral values are combined across the branch datasets row by row.
+        assert list(d["VAt_1"]) == [1.5, 2.5]
+        # Case reuses the first branch dataset's components: no leak into the input.
+        assert result["DS_r2"].components["VAt_1"].data_type == Integer
+
+    @pytest.mark.parametrize("use_duckdb", [False, True])
+    def test_sum_binary_stays_integer(self, use_duckdb: bool) -> None:
+        result = run(
+            script=_SUM_RULE + "DS_r <- DS_1 + DS_2;",
+            data_structures=_ds_pair(_INT_VA_DS),
+            datapoints=_int_va_dp(),
+            use_duckdb=use_duckdb,
+        )
+        ds_r = result["DS_r"]
+        assert ds_r.components["VAt_1"].data_type == Integer
+        d = ds_r.data.sort_values("Id_1").reset_index(drop=True)
+        assert list(d["VAt_1"]) == [3, 5]
+
+
 # -- Unit tests for the combination-point check helpers --
 
 
@@ -1092,6 +1249,47 @@ class TestViralCheckHelpers:
 
     def test_combined_viral_components_empty_for_single_operand(self) -> None:
         assert combined_viral_components([_viral_ds("A", ["VAt_1"])]) == []
+
+    @pytest.mark.parametrize("fn", ["sum", "avg"])
+    def test_require_rules_sum_avg_non_numeric_raises(self, fn: str) -> None:
+        registry = ViralPropagationRegistry()
+        registry.register(
+            ViralPropagationRule(
+                name="VP", signature_type="variable", target="VAt_1", aggregate_function=fn
+            )
+        )
+        set_current_registry(registry)
+        with pytest.raises(SemanticError) as exc:
+            require_rules([Component("VAt_1", String, Role.VIRAL_ATTRIBUTE, True)])
+        assert "1-3-3-5" in str(exc.value)
+
+    def test_apply_viral_return_types_promotes_avg_without_mutating_input(self) -> None:
+        registry = ViralPropagationRegistry()
+        registry.register(
+            ViralPropagationRule(
+                name="AV", signature_type="variable", target="VAt_1", aggregate_function="avg"
+            )
+        )
+        set_current_registry(registry)
+        comp = Component("VAt_1", Integer, Role.VIRAL_ATTRIBUTE, True)
+        # The result entry shares the input object, as in Analytic/Case validate.
+        result_components = {"VAt_1": comp}
+        apply_viral_return_types([comp], result_components)
+        assert result_components["VAt_1"].data_type == Number
+        assert comp.data_type == Integer
+
+    def test_apply_viral_return_types_sum_keeps_type(self) -> None:
+        registry = ViralPropagationRegistry()
+        registry.register(
+            ViralPropagationRule(
+                name="SM", signature_type="variable", target="VAt_1", aggregate_function="sum"
+            )
+        )
+        set_current_registry(registry)
+        comp = Component("VAt_1", Integer, Role.VIRAL_ATTRIBUTE, True)
+        result_components = {"VAt_1": comp}
+        apply_viral_return_types([comp], result_components)
+        assert result_components["VAt_1"].data_type == Integer
 
 
 # -- Row-preserving operators copy viral attributes, they do NOT execute the rule (#906) --


### PR DESCRIPTION
## Summary

Issue #910: viral propagation rules with `aggregate avg`/`sum` raised `1-3-3-5` ("va has type String") even though every dataset actually combined declares `va` as Number, while `min`/`max` worked. Two defects fixed:

1. **Type check ran at definition time over all input datasets.** The sum/avg numeric-type check in `visit_ViralPropagationDef` scanned every input dataset — including datasets never combined, or never referenced by the script at all. The variable-signature check now lives in `require_rules`, which runs exactly at the VTL 2.2 combination points (binary ops over two datasets, joins, aggregation group-by, analytic partitions, hierarchy roll-ups, if/case over datasets), so the rule is validated only where it actually executes. Value-domain-signature rules keep the definition-time check, since a value domain's type is intrinsic to the rule target.

2. **`avg` on an Integer viral attribute crashed.** The result kept the Integer type, and the pandas backend raised `pyarrow.lib.ArrowInvalid: Float value 1.5 truncated converting to int64` on fractional means. The new `apply_viral_return_types` helper promotes a viral attribute combined under an `avg` rule to `Number` in the result structure, mirroring the `Avg` operator's `return_type` (`sum` keeps the input type, mirroring `Sum`). Promoted entries are replaced with copies so operators that share component objects with their inputs (analytic, case) never mutate the input dataset structure.

Both backends are covered: the semantic pass is shared, and the DuckDB data path already produced DOUBLE for avg — the declared schema now matches it.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest` — 5405 passed, 27 skipped)
- [x] Documentation updated (if applicable) — no change needed, the 1-3-3-5 message text is unchanged

## Impact / Risk

- Behavior change: a sum/avg rule over a non-numeric viral attribute now raises `1-3-3-5` only when that attribute is actually combined; scripts that previously failed at definition time despite never executing the rule now run (the #910 report).
- Output structure change: an Integer viral attribute combined under an `avg` rule is now typed `Number` in the result (previously Integer, which crashed at runtime on fractional means).
- No public API or SDMX compatibility changes.

## Notes

- Forward-port to `main` will follow in a separate PR.
- When value domains land on components, `require_rules` will also cover value-domain rules at combination points via `rule_for`; their definition-time check stays meanwhile.

Fixes #910