### PR TITLE
Fix #964: dateadd shifts a Data Set's reference time Identifier

### DIFF
--- a/src/vtlengine/Operators/Time.py
+++ b/src/vtlengine/Operators/Time.py
@@ -1070,6 +1070,22 @@ class Date_Add(Parametrized):
     op = DATE_ADD
 
     @classmethod
+    def _dateadd_targets(cls, operand: Dataset) -> List[Component]:
+        """The Components a Data Set operand shifts.
+
+        The reference manual types the operand as ``dataset {identifier<time> _,
+        identifier _*}``, so the reference time Identifier is what moves. A Data Set
+        whose only time Components are Measures is accepted as well, and those Measures
+        move instead, which is what the operator did before it reached an Identifier at
+        all. Components of any other type are left alone either way, since
+        there is no date to add to.
+        """
+        time_ids = [c for c in operand.get_identifiers() if c.data_type in (Date, TimePeriod)]
+        if time_ids:
+            return time_ids
+        return [m for m in operand.get_measures() if m.data_type in (Date, TimePeriod)]
+
+    @classmethod
     def validate(
         cls, operand: Union[Scalar, DataComponent, Dataset], param_list: List[Scalar]
     ) -> Union[Scalar, DataComponent, Dataset]:
@@ -1137,13 +1153,13 @@ class Date_Add(Parametrized):
             and operand.data is not None
         ):
             result.data = operand.data.copy()
-            for measure in operand.get_measures():
-                if measure.data_type in [Date, TimePeriod]:
-                    result.data[measure.name] = result.data[measure.name].map(
-                        lambda x: cls.py_op(str(x), shift, period, measure.data_type == TimePeriod),
-                        na_action="ignore",
-                    )
-                    measure.data_type = Date
+            for comp in cls._dateadd_targets(operand):
+                is_period = comp.data_type == TimePeriod
+                result.data[comp.name] = result.data[comp.name].map(
+                    lambda x: cls.py_op(str(x), shift, period, is_period),  # noqa: B023
+                    na_action="ignore",
+                )
+                comp.data_type = Date
 
         if isinstance(result, (Scalar, DataComponent)):
             result.data_type = Date

--- a/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
+++ b/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
@@ -1690,6 +1690,28 @@ FROM (
     WHERE d_prev IS NOT NULL AND d_prev <> d_next
 )""".strip()
 
+    @staticmethod
+    def _dateadd_targets(ds: Dataset) -> List[Component]:
+        """The Components a Data Set operand of dateadd shifts.
+
+        The reference time Identifier when the Data Set has one, matching the operand
+        type the manual gives, and otherwise its Date or Time_Period Measures. Any other
+        Component is passed through: applying a date shift to a String Measure used to
+        abort the whole query.
+        """
+        time_ids = [
+            c
+            for c in ds.components.values()
+            if c.role == Role.IDENTIFIER and c.data_type in (Date, TimePeriod)
+        ]
+        if time_ids:
+            return time_ids
+        return [
+            c
+            for c in ds.components.values()
+            if c.role == Role.MEASURE and c.data_type in (Date, TimePeriod)
+        ]
+
     def visit_ParamOp_dateadd(self, node: AST.ParamOp) -> str:
         """Visit DATEADD operation: dateadd(op, shiftNumber, periodInd)."""
         operand_node = node.children[0]
@@ -1703,23 +1725,30 @@ FROM (
         if operand_type == _DATASET:
             ds_node = operand_node
             ds = self._get_dataset_structure(ds_node)
-            has_tp = ds is not None and any(
-                c.data_type == TimePeriod for c in ds.components.values() if c.role == Role.MEASURE
-            )
+            targets = self._dateadd_targets(ds)
+            target_names = {c.name for c in targets}
 
-            if has_tp and self.current_assignment:
+            if self.current_assignment:
                 out_ds = self.output_datasets.get(self.current_assignment)
                 if out_ds is not None:
                     for comp in out_ds.components.values():
-                        if comp.data_type == TimePeriod:
+                        if comp.name in target_names and comp.data_type == TimePeriod:
                             comp.data_type = Date
 
-            def _dateadd_expr(col_ref: str) -> str:
-                if has_tp:
+            def _dateadd_expr(col_ref: str, is_period: bool) -> str:
+                if is_period:
                     return f"vtl_tp_dateadd(vtl_period_parse({col_ref}), {shift_sql}, {period_sql})"
                 return f"vtl_dateadd({col_ref}, {shift_sql}, {period_sql})"
 
-            return self._apply_measures(ds_node, _dateadd_expr)
+            cols = []
+            for name, comp in ds.components.items():
+                col = quote_name(name)
+                if name in target_names:
+                    cols.append(f"{_dateadd_expr(col, comp.data_type == TimePeriod)} AS {col}")
+                else:
+                    cols.append(col)
+            src = self._get_dataset_sql(ds_node)
+            return SQLBuilder().select(*cols).from_table(src).build()
         else:
             operand_sql = self.visit(operand_node)
             if is_tp:

--- a/tests/NewOperators/Time/data/DataSet/input/28-1.csv
+++ b/tests/NewOperators/Time/data/DataSet/input/28-1.csv
@@ -1,0 +1,4 @@
+Id_1,Id_date,Me_num,Me_str
+A,2001-01-01,1.1,hello
+A,2002-02-01,2.2,world
+B,2003-03-01,3.3,abc

--- a/tests/NewOperators/Time/data/DataSet/output/28-1.csv
+++ b/tests/NewOperators/Time/data/DataSet/output/28-1.csv
@@ -1,0 +1,4 @@
+Id_1,Id_date,Me_num,Me_str
+A,2001-01-15,1.1,hello
+A,2002-02-15,2.2,world
+B,2003-03-15,3.3,abc

--- a/tests/NewOperators/Time/data/DataStructure/input/28-1.json
+++ b/tests/NewOperators/Time/data/DataStructure/input/28-1.json
@@ -1,0 +1,33 @@
+{
+  "datasets": [
+    {
+      "name": "DS_1",
+      "DataStructure": [
+        {
+          "name": "Id_1",
+          "role": "Identifier",
+          "type": "String",
+          "nullable": false
+        },
+        {
+          "name": "Id_date",
+          "role": "Identifier",
+          "type": "Date",
+          "nullable": false
+        },
+        {
+          "name": "Me_num",
+          "role": "Measure",
+          "type": "Number",
+          "nullable": true
+        },
+        {
+          "name": "Me_str",
+          "role": "Measure",
+          "type": "String",
+          "nullable": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/NewOperators/Time/data/DataStructure/output/28-1.json
+++ b/tests/NewOperators/Time/data/DataStructure/output/28-1.json
@@ -1,0 +1,33 @@
+{
+  "datasets": [
+    {
+      "name": "DS_r",
+      "DataStructure": [
+        {
+          "name": "Id_1",
+          "role": "Identifier",
+          "type": "String",
+          "nullable": false
+        },
+        {
+          "name": "Id_date",
+          "role": "Identifier",
+          "type": "Date",
+          "nullable": false
+        },
+        {
+          "name": "Me_num",
+          "role": "Measure",
+          "type": "Number",
+          "nullable": true
+        },
+        {
+          "name": "Me_str",
+          "role": "Measure",
+          "type": "String",
+          "nullable": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/NewOperators/Time/test_new_time.py
+++ b/tests/NewOperators/Time/test_new_time.py
@@ -25,6 +25,7 @@ ds_param = [
     ("12", 'DS_r := dateadd(DS_1, 9, "A");'),
     ("13", 'DS_r := DS_1[calc Me_2 := dateadd(Me_1, 1889432, "D")];'),
     ("14", 'DS_r := DS_1[calc Me_2 := dateadd(Me_1, 1889432, "D")];'),
+    ("28", 'DS_r := dateadd(DS_1, 2, "W");'),
 ]
 
 error_param = [


### PR DESCRIPTION
## Summary

`dateadd` over a Data Set ignored the operand's reference time Identifier, and neither engine
limited itself to time Components:

| engine | before |
| --- | --- |
| pandas | shifted Date and Time_Period **Measures** only, so a Data Set whose time Component is an Identifier came back unchanged |
| DuckDb | applied the shift to **every** Measure, aborting with `Invalid date format, must be YYYY-MM-DD: hello` on a String Measure |

The [reference manual](https://sdmx-twg.github.io/vtl/v2.2/reference_manual/operators/Time%20operators/Add%20time%20unit%20to%20date/index.html)
types the operand as `dataset { identifier <time> _ , identifier _* }`, the same signature as
`timeshift`, so the reference time Identifier is what moves.

Both engines now share one rule: shift the time Identifier when the Data Set has one, otherwise
its Date or Time_Period Measures, and pass every other Component through.

On the Data Set from the issue, both engines now give:

| Id_date in | Id_date out | Me_str |
| --- | --- | --- |
| 2001-01-01 | 2001-01-15 | hello, unchanged |

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- A Data Set with a time Identifier now has that Identifier shifted rather than being returned
  unchanged (pandas) or failing (DuckDb). A uniform shift is injective, so the Identifier stays
  unique.
- Non-time Measures are no longer touched on DuckDb, which is what made the query abort.
- Data Sets whose only time Components are Measures keep their current behaviour, so the 12
  existing Data Set cases are unaffected.

## Notes

The Measure fallback is deliberate. The 12 existing Data Set cases pass an operand with an Integer
Identifier and a Date Measure, which does not match the documented signature; rejecting those would
be a breaking change, so they keep working rather than having a removal bundled into this fix. That
stricter alignment is worth its own task if it is wanted.

Code `28` in `ds_param` covers a Date Identifier alongside Number and String Measures, pinning both
halves of the rule. It fails on both engines against the previous code.

---

Closes #964

