### PR TITLE
Fix #966: reject a mismatched duration in yeartoday and monthtoday

### DIFF
--- a/src/vtlengine/duckdb_transpiler/io/_execution.py
+++ b/src/vtlengine/duckdb_transpiler/io/_execution.py
@@ -120,6 +120,15 @@ def _map_query_error(error: duckdb.Error, sql_query: str) -> Exception:
                 date_val = parts[1]
         return RunTimeError("2-1-19-8", date=date_val)
 
+    # yeartoday / monthtoday: the duration does not have the shape the operator takes
+    # (mirrors 2-1-19-22)
+    if "vtl 2-1-19-22" in msg_lower:
+        op = "monthtoday" if "monthtoday" in msg_lower else "yeartoday"
+        m = re.search(r"expected (\S+) got (.*?)(?:\n|$)", msg)
+        expected = m.group(1) if m else ("PnMnD" if op == "monthtoday" else "PnYnD")
+        value = m.group(2).strip() if m else "unknown"
+        return RunTimeError("2-1-19-22", op=op, value=value, expected=expected)
+
     # VTL macro vtl_div: denominator was 0 (mirrors Python engine error 2-1-15-6)
     if "vtl 2-1-15-6" in msg_lower:
         return RunTimeError("2-1-15-6", op="/")

--- a/src/vtlengine/duckdb_transpiler/sql/time_operators.sql
+++ b/src/vtlengine/duckdb_transpiler/sql/time_operators.sql
@@ -179,20 +179,28 @@ CREATE OR REPLACE MACRO vtl_daytomonth(days) AS (
 -- ============================================================================
 
 CREATE OR REPLACE MACRO vtl_yeartoday(dur) AS (
-    CASE WHEN dur IS NULL THEN 
-        NULL 
-    ELSE
-        COALESCE(TRY_CAST(REGEXP_EXTRACT(dur, '(\d+)Y', 1) AS INTEGER), 0) * 365
-        + COALESCE(TRY_CAST(REGEXP_EXTRACT(dur, '(\d+)D', 1) AS INTEGER), 0)
+    CASE
+        WHEN dur IS NULL THEN
+            NULL
+        -- Only PnYnD is accepted. Extracting the parts alone treated anything else as
+        -- zero, so an unrelated mask returned a number instead of failing.
+        WHEN NOT REGEXP_MATCHES(dur, '^P(\d+Y\d+D|\d+Y|\d+D)$') THEN
+            error('VTL 2-1-19-22: yeartoday expected PnYnD got ' || dur)
+        ELSE
+            COALESCE(TRY_CAST(REGEXP_EXTRACT(dur, '(\d+)Y', 1) AS INTEGER), 0) * 365
+            + COALESCE(TRY_CAST(REGEXP_EXTRACT(dur, '(\d+)D', 1) AS INTEGER), 0)
     END
 );
 
 CREATE OR REPLACE MACRO vtl_monthtoday(dur) AS (
-    CASE WHEN dur IS NULL THEN 
-        NULL 
-    ELSE
-        COALESCE(TRY_CAST(REGEXP_EXTRACT(dur, '(\d+)M', 1) AS INTEGER), 0) * 30
-        + COALESCE(TRY_CAST(REGEXP_EXTRACT(dur, '(\d+)D', 1) AS INTEGER), 0)
+    CASE
+        WHEN dur IS NULL THEN
+            NULL
+        WHEN NOT REGEXP_MATCHES(dur, '^P(\d+M\d+D|\d+M|\d+D)$') THEN
+            error('VTL 2-1-19-22: monthtoday expected PnMnD got ' || dur)
+        ELSE
+            COALESCE(TRY_CAST(REGEXP_EXTRACT(dur, '(\d+)M', 1) AS INTEGER), 0) * 30
+            + COALESCE(TRY_CAST(REGEXP_EXTRACT(dur, '(\d+)D', 1) AS INTEGER), 0)
     END
 );
 

--- a/tests/NewOperators/UnaryTime/test_time_operators.py
+++ b/tests/NewOperators/UnaryTime/test_time_operators.py
@@ -39,6 +39,11 @@ scalar_time_params = [
     ('dayofmonth(cast("2022Q1", time_period))', 31),
     ('dayofyear(cast("2023-01-12", date))', 12),
     ('dayofyear(cast("2022Q1", time_period))', 90),
+    ('yeartoday("P1Y2D")', 367),
+    ('yeartoday("P1Y")', 365),
+    ('yeartoday("P10D")', 10),
+    ('monthtoday("P3M2D")', 92),
+    ('monthtoday("P5D")', 5),
 ]
 
 scalar_time_error_params = [
@@ -50,6 +55,10 @@ scalar_time_error_params = [
     ('getmonth(cast("2023-01-12/2024-03-25", time))', SemanticError, "1-1-19-10"),
     ('dayofmonth(cast("2023-01-12/2024-05-29", time))', SemanticError, "1-1-19-10"),
     ('dayofyear(cast("2023-01-12/2024-06-08", time))', SemanticError, "1-1-19-10"),
+    ('yeartoday("P1M")', RunTimeError, "2-1-19-22"),
+    ('yeartoday("hello")', RunTimeError, "2-1-19-22"),
+    ('monthtoday("P3Y")', RunTimeError, "2-1-19-22"),
+    ('monthtoday("P1Y1M")', RunTimeError, "2-1-19-22"),
 ]
 
 


### PR DESCRIPTION
## Summary

`yeartoday` and `monthtoday` returned a number on DuckDb when given a duration that does not have
the shape the operator takes, where the pandas engine raised `2-1-19-22`. The macros extracted the
components they recognised and coalesced everything else to zero:

```sql
COALESCE(TRY_CAST(REGEXP_EXTRACT(dur, '(\d+)Y', 1) AS INTEGER), 0) * 365
+ COALESCE(TRY_CAST(REGEXP_EXTRACT(dur, '(\d+)D', 1) AS INTEGER), 0)
```

So `yeartoday("P1M")` matched neither component and gave `0`. Two cases beyond the report are worse
than a zero: `yeartoday("hello")` also gave `0`, and `monthtoday("P1Y1M")` gave `30` by taking the
month and silently discarding the year, which is a plausible wrong answer rather than an obvious
one.

Both macros now check the whole string before extracting anything, using the same grammar the
pandas engine enforces:

- `yeartoday` accepts `^P(\d+Y\d+D|\d+Y|\d+D)$`
- `monthtoday` accepts `^P(\d+M\d+D|\d+M|\d+D)$`

These are written without the lookahead in the pandas patterns, which RE2 does not support, but they
accept and reject exactly the same strings.

A mismatch is raised with `error('VTL 2-1-19-22: ...')` and rebuilt in `_map_query_error`, which is
how the other macro errors already reach the caller. The messages now match the pandas ones exactly,
including the operator, the offending value and the expected shape:

```
pandas: At op yeartoday: Invalid ISO 8601 duration format 'P1M', expected PnYnD Please check transformation with output Dataset r
duckdb: At op yeartoday: Invalid ISO 8601 duration format 'P1M', expected PnYnD
```

The trailing clause on the pandas side is the interpreter's generic decoration, not part of the
message.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- A script passing a mismatched duration to either operator now fails on DuckDb instead of returning
  a number. Anything passing a well formed duration is unaffected: `P1Y2D`, `P1Y`, `P10D`, `P3M2D`
  and `P5D` all return the same values as before on both engines.
- The pandas engine is untouched, since it already validated.
- Ten cases were compared across the two engines, five rejected and five accepted, with no
  divergence left.

## Notes

The new cases go in the existing scalar lists of
`tests/NewOperators/UnaryTime/test_time_operators.py`, which drive `run_scalar_expression`, so they
match the reproduction in the issue without needing fixtures. Four cover the rejected shapes and
five the accepted ones. The four fail on DuckDb against the previous code, and pass on pandas either
way.

---

Closes #966
