### PR TITLE
Fix #987: null survives a viral propagation round trip

### DIFF
--- a/src/vtlengine/AST/ASTConstructor.py
+++ b/src/vtlengine/AST/ASTConstructor.py
@@ -173,7 +173,9 @@ class ASTVisitor:
 
         propagation_name = Terminals().visitVarID(ctx_list[3]).value
         signature_type, target = self.visitVpSignature(ctx_list[5])
-        enumerated_clauses, aggregate_clause, default_value = self.visitVpBody(ctx_list[8])
+        enumerated_clauses, aggregate_clause, default_value, has_default = self.visitVpBody(
+            ctx_list[8]
+        )
 
         token_info = extract_token_info(ctx)
 
@@ -184,6 +186,7 @@ class ASTVisitor:
             enumerated_clauses=enumerated_clauses,
             aggregate_clause=aggregate_clause,
             default_value=default_value,
+            has_default=has_default,
             **token_info,
         )
 
@@ -200,6 +203,7 @@ class ASTVisitor:
         enumerated_clauses: List[EnumeratedVpClause] = []
         aggregate_clause: Optional[AggregateVpClause] = None
         default_value: Optional[str] = None
+        has_default = False
 
         for child in ctx_list:
             if child.is_terminal:
@@ -210,8 +214,9 @@ class ASTVisitor:
                 aggregate_clause = self.visitAggregationVpClause(child)
             elif child.ctx_id == RC.DEFAULT_VP_CLAUSE:
                 default_value = self.visitDefaultVpClause(child)
+                has_default = True
 
-        return enumerated_clauses, aggregate_clause, default_value
+        return enumerated_clauses, aggregate_clause, default_value, has_default
 
     def visitEnumeratedVpClause(self, ctx: Any) -> Any:
         """enumeratedVpClause: (IDENTIFIER COLON)? WHEN vpCondition THEN constant ;"""

--- a/src/vtlengine/AST/ASTString.py
+++ b/src/vtlengine/AST/ASTString.py
@@ -240,19 +240,35 @@ class ASTString(ASTTemplate):
             )
 
     # ---------------------- Viral Propagation ----------------------
+    @staticmethod
+    def _vp_constant(value: Any) -> str:
+        """A viral propagation constant written the way it was read.
+
+        ``null`` reaches the rule as None and is a keyword rather than a value, so
+        quoting it turned it into the string "None". Numbers and booleans
+        are not quoted either.
+        """
+        if value is None:
+            return "null"
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)):
+            return str(value)
+        return f'"{value}"'
+
     def visit_ViralPropagationDef(self, node: AST.ViralPropagationDef) -> None:
         clauses_strs: list[str] = []
         for clause in node.enumerated_clauses:
             clause_str = ""
             if clause.name is not None:
                 clause_str += f"{clause.name} : "
-            values_str = " and ".join([f'"{v}"' for v in clause.values])
-            clause_str += f'when {values_str} then "{clause.result}"'
+            values_str = " and ".join([self._vp_constant(v) for v in clause.values])
+            clause_str += f"when {values_str} then {self._vp_constant(clause.result)}"
             clauses_strs.append(clause_str)
         if node.aggregate_clause is not None:
             clauses_strs.append(f"aggregate {node.aggregate_clause.function}")
-        if node.default_value is not None:
-            clauses_strs.append(f'else "{node.default_value}"')
+        if node.has_default:
+            clauses_strs.append(f"else {self._vp_constant(node.default_value)}")
 
         if self.pretty:
             self.vtl_script += (

--- a/src/vtlengine/AST/__init__.py
+++ b/src/vtlengine/AST/__init__.py
@@ -795,6 +795,7 @@ class ViralPropagationDef(AST):
     enumerated_clauses: List[EnumeratedVpClause]
     aggregate_clause: Optional[AggregateVpClause]
     default_value: Optional[str]
+    has_default: bool = False
 
     __eq__ = AST.ast_equality
 

--- a/tests/AST/data/prettier/GH_987.vtl
+++ b/tests/AST/data/prettier/GH_987.vtl
@@ -1,0 +1,12 @@
+define viral propagation At_1 (variable At_1) is
+    when null then null;
+    when "Ay" then null;
+    when "Bq" then "Bq";
+    else null
+end viral propagation;
+
+define viral propagation At_2 (variable At_2) is
+    when "Ay" then "Ay"
+end viral propagation;
+
+DS_r <- DS_1;

--- a/tests/AST/data/prettier/reference_GH_987.vtl
+++ b/tests/AST/data/prettier/reference_GH_987.vtl
@@ -1,0 +1,13 @@
+define viral propagation At_1(variable At_1) is
+	when null then null;
+	when "Ay" then null;
+	when "Bq" then "Bq";
+	else null
+end viral propagation;
+
+define viral propagation At_2(variable At_2) is
+	when "Ay" then "Ay"
+end viral propagation;
+
+DS_r <-
+	DS_1;

--- a/tests/AST/data/vtl/GH_987.vtl
+++ b/tests/AST/data/vtl/GH_987.vtl
@@ -1,0 +1,12 @@
+define viral propagation At_1 (variable At_1) is
+    when null then null;
+    when "Ay" then null;
+    when "Bq" then "Bq";
+    else null
+end viral propagation;
+
+define viral propagation At_2 (variable At_2) is
+    when "Ay" then "Ay"
+end viral propagation;
+
+DS_r <- DS_1;

--- a/tests/AST/test_AST_String.py
+++ b/tests/AST/test_AST_String.py
@@ -36,6 +36,7 @@ params = [
     "component_roles.vtl",
     "hierarchical_unquoted_codeitems.vtl",
     "join_body_clauses.vtl",
+    "GH_987.vtl",
 ]
 
 params_prettier = [
@@ -65,6 +66,7 @@ params_prettier = [
     ("time_agg.vtl", "reference_time_agg.vtl"),
     ("time_agg_ref.vtl", "reference_time_agg_ref.vtl"),
     ("viral_propagation.vtl", "reference_viral_propagation.vtl"),
+    ("GH_987.vtl", "reference_GH_987.vtl"),
 ]
 
 


### PR DESCRIPTION
## Summary

A viral propagation rule using `null` did not survive `create_ast` followed by `ASTString`:

```
in:   when null then null;  ...  else null
out:  when "None" then "None";  ...        <- the else clause is gone
```

Two separate causes:

- `ASTString` wrapped every constant in quotes, so `null`, which reaches the rule as `None`, was
  rendered as the string `"None"`. Constants are now written the way they were read, with `null` as
  a keyword. Numbers and booleans are no longer quoted either, since the grammar accepts any
  `constant` in these clauses.
- The else clause was emitted only when `default_value` was set, and `else null` leaves it `None`,
  which is exactly what a rule with no else clause looks like. `ViralPropagationDef` now records
  whether one was written.

> [!NOTE]
> `resolve_single` and `resolve_group` both return `rule.default_value`, so `else null` and no else
> clause already resolve identically. The new flag exists for the round trip and changes no
> behaviour; the field carries a default, so the single place that builds the rule is unaffected.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- `prettify` and `ASTString` output changes only for rules that use `null`, a number or a boolean,
  which previously came out quoted or were dropped. Rules built from strings are unchanged.
- No change to how a rule resolves at runtime.
- Checked over seven shapes, each idempotent and each keeping the else clause present or absent as
  written: no else, `else "ZZ"`, `else null`, `aggregate max`, a binary `when ... and ...`, a named
  rule, and a `valuedomain` target.

## Notes

`GH_987.vtl` is registered in both `params_prettier`, which compares the prettified text against a
reference, and `params`, which renders and reparses and compares the two ASTs. The second catches
the dropped else through the new flag. Both fail against the previous code.

---

Closes #987

