### PR TITLE
Fix #1053: the DuckDb engine rejects columns outside the DataStructure

### DIFF
--- a/src/vtlengine/duckdb_transpiler/io/_io.py
+++ b/src/vtlengine/duckdb_transpiler/io/_io.py
@@ -18,6 +18,7 @@ from vtlengine.duckdb_transpiler.io._validation import (
     build_create_table_sql,
     build_csv_column_types,
     build_select_columns,
+    check_extra_columns,
     check_missing_identifiers,
     get_column_sql_type,
     handle_sdmx_columns,
@@ -260,8 +261,9 @@ def load_datapoints_duckdb(
         # 4. Handle SDMX-CSV special columns
         keep_columns = handle_sdmx_columns(csv_columns, components)
 
-        # Check required identifier columns exist
+        # Check required identifier columns exist, and that no other column is left
         check_missing_identifiers(id_columns, keep_columns, file_path)
+        check_extra_columns(keep_columns, components, dataset_name)
 
         # 5. Build column type mapping and SELECT expressions
         csv_dtypes = build_csv_column_types(components, keep_columns)
@@ -350,6 +352,7 @@ def _load_parquet(
 
         keep_columns = handle_sdmx_columns(parquet_cols, components)
         check_missing_identifiers(id_columns, keep_columns, file_path)
+        check_extra_columns(keep_columns, components, dataset_name)
 
         select_exprs = _build_dataframe_select_columns(components, df_columns=parquet_cols)
 
@@ -624,6 +627,10 @@ def register_dataframes(
             continue
 
         components = input_datasets[name].components
+
+        # A DataFrame carries its columns as they are, so the SDMX markers are taken
+        # out before what is left is checked against the DataStructure.
+        check_extra_columns(handle_sdmx_columns(list(df.columns), components), components, name)
 
         # Detect Date columns that contain time values → TIMESTAMP instead of DATE
         type_overrides = _detect_date_type_overrides(df, components)

--- a/src/vtlengine/duckdb_transpiler/io/_validation.py
+++ b/src/vtlengine/duckdb_transpiler/io/_validation.py
@@ -482,6 +482,21 @@ def build_select_columns(
     return select_cols
 
 
+def check_extra_columns(
+    columns: List[str],
+    components: Dict[str, Component],
+    dataset_name: str,
+) -> None:
+    """Reject the columns the DataStructure does not define.
+
+    The SDMX marker columns are taken out by ``handle_sdmx_columns`` before this
+    runs, so what is left is what the pandas loader rejects too.
+    """
+    extra_columns = sorted(set(columns) - set(components))
+    if extra_columns:
+        raise DataLoadError("0-3-1-15", name=dataset_name, extra_columns=", ".join(extra_columns))
+
+
 def check_missing_identifiers(
     id_columns: List[str],
     keep_columns: List[str],

--- a/tests/API/test_api.py
+++ b/tests/API/test_api.py
@@ -2199,6 +2199,49 @@ def test_run_error_on_extra_dataframe_columns():
         run(script=script, data_structures=data_structures, datapoints=datapoints)
 
 
+@pytest.mark.parametrize("use_duckdb", [False, True], ids=["pandas", "duckdb"])
+@pytest.mark.parametrize("input_kind", ["dataframe", "csv", "parquet"])
+def test_run_error_on_extra_columns(tmp_path, input_kind, use_duckdb):
+    """Whatever carries the input, a column outside the DataStructure is rejected.
+
+    The DuckDb engine selected the DataStructure components and read past the rest,
+    so it ran a script the pandas engine refused to load (issue #1053).
+    """
+    if input_kind == "parquet" and not use_duckdb:
+        pytest.skip("the pandas loader reads a Parquet file as a CSV and fails earlier")
+
+    data_structures = {
+        "datasets": [
+            {
+                "name": "DS_1",
+                "DataStructure": [
+                    {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+                    {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+                ],
+            }
+        ]
+    }
+    df = pd.DataFrame({"Id_1": [1, 2], "Me_1": [10.0, 20.0], "Me_2": ["a", "b"]})
+    if input_kind == "dataframe":
+        datapoints = {"DS_1": df}
+    elif input_kind == "csv":
+        csv_path = tmp_path / "DS_1.csv"
+        df.to_csv(csv_path, index=False)
+        datapoints = {"DS_1": str(csv_path)}
+    else:
+        parquet_path = tmp_path / "DS_1.parquet"
+        df.to_parquet(parquet_path, index=False)
+        datapoints = {"DS_1": str(parquet_path)}
+
+    with pytest.raises(DataLoadError, match="0-3-1-15"):
+        run(
+            script="DS_r <- DS_1 * 10;",
+            data_structures=data_structures,
+            datapoints=datapoints,
+            use_duckdb=use_duckdb,
+        )
+
+
 def test_run_error_on_missing_non_nullable_column():
     """Missing non-nullable columns in the input DataFrame raise an error."""
     script = "DS_r <- DS_1;"


### PR DESCRIPTION
## Summary

`0-3-1-15` was raised only on the pandas loading path, so with `use_duckdb=True` a column the
DataStructure does not define was silently dropped and the script ran. The DuckDb loaders build
their `INSERT ... SELECT` from the components, so anything else in the input was read and never
selected.

| Input | pandas | DuckDb before | DuckDb now |
| --- | --- | --- | --- |
| DataFrame | `0-3-1-15` | loads, column ignored | `0-3-1-15` |
| Plain CSV | `0-3-1-15` | loads, column ignored | `0-3-1-15` |
| Parquet | `0-1-1-8`, the loader reads it as a CSV | loads, column ignored | `0-3-1-15` |

One helper, `check_extra_columns`, is called from the three paths that take input:
`load_datapoints_duckdb` for CSV, `_load_parquet`, and `register_dataframes`.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`, both `duckdb` and `pandas` backends)
- [ ] Documentation updated (if applicable)

## Impact / Risk

- **Breaking on DuckDb**: input carrying a column outside the DataStructure now fails to load
  where it used to run. It already failed on the pandas engine, so this closes a divergence
  rather than opening one, and Parquet input, which is DuckDb-only today, is covered by the same
  rule.
- Clean input is unaffected on either engine.
- Needs a release note.

## Notes

The check runs after `handle_sdmx_columns`, which takes out `DATAFLOW`, `STRUCTURE`,
`STRUCTURE_ID` and `ACTION` — the same four columns `_sanitize_sdmx_columns` removes on the
pandas path before its own check. SDMX-ML and SDMX-JSON files reach both loaders through
`load_sdmx_datapoints` already sanitised, so they pass as before and the 159 SDMX tests stay
green. Dropping the remaining columns for inputs identified as SDMX is #1052, and belongs on both
engines at once.

Closes #1053

