### PR TITLE
Fix #1073: a String value keeps the double quotes it holds, on all four load paths

### DIFF
--- a/src/vtlengine/duckdb_transpiler/io/_validation.py
+++ b/src/vtlengine/duckdb_transpiler/io/_validation.py
@@ -478,8 +478,7 @@ def build_select_columns(
                     stripped = f"NULLIF({stripped}, '')"
                 select_cols.append(f'CAST({stripped} AS BOOLEAN) AS "{comp_name}"')
             elif csv_type == "VARCHAR" and comp.data_type == String:
-                # Strip double quotes from String values (match pandas loader behavior)
-                expr = f"""REPLACE("{comp_name}", '"', '')"""
+                expr = f'"{comp_name}"'
                 if comp.nullable:
                     expr = f"NULLIF({expr}, '')"
                 select_cols.append(f'{expr} AS "{comp_name}"')

--- a/src/vtlengine/files/parser/__init__.py
+++ b/src/vtlengine/files/parser/__init__.py
@@ -273,9 +273,7 @@ def _validate_pandas(
                     except ValueError:
                         raise ValueError(f"Duration values are not correct in column {comp_name}")
             else:
-                data[comp_name] = data[comp_name].map(
-                    lambda x: str(x).replace('"', ""), na_action="ignore"
-                )
+                data[comp_name] = data[comp_name].map(str, na_action="ignore")
             data[comp_name] = data[comp_name].astype(comp.data_type.dtype())  # type: ignore[call-overload]
 
     except (ValueError, InputValidationException) as e:

--- a/tests/DataLoad/test_dataload.py
+++ b/tests/DataLoad/test_dataload.py
@@ -1146,3 +1146,55 @@ class TestBOMHandling:
         ds = result["DS_r"]
         assert "Id_1" in ds.data.columns
         assert "\ufeffId_1" not in ds.data.columns
+
+
+_STRING_STRUCTURE = {
+    "datasets": [
+        {
+            "name": "DS_1",
+            "DataStructure": [
+                {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+                {"name": "Me_1", "type": "String", "role": "Measure", "nullable": True},
+            ],
+        }
+    ]
+}
+
+
+@pytest.mark.parametrize("use_duckdb", [False, True], ids=["pandas", "duckdb"])
+class TestStringKeepsItsQuotes:
+    """A double quote a String value holds is part of it, whichever of the four ways
+    the value reaches the engine (issue #1073)."""
+
+    def _load(self, datapoints, use_duckdb):
+        result = run(
+            script="DS_r <- DS_1;",
+            data_structures=_STRING_STRUCTURE,
+            datapoints=datapoints,
+            use_duckdb=use_duckdb,
+        )
+        return result["DS_r"].data["Me_1"].tolist()
+
+    def test_dataframe(self, use_duckdb):
+        """The DuckDb engine kept the quote here while the other three took it out."""
+        data_df = pd.DataFrame({"Id_1": [1], "Me_1": ['he"llo']})
+        assert self._load({"DS_1": data_df}, use_duckdb) == ['he"llo']
+
+    def test_csv(self, tmp_path: Path, use_duckdb):
+        """The same value written in a file."""
+        csv_path = tmp_path / "DS_1.csv"
+        csv_path.write_text('Id_1,Me_1\n1,he"llo\n')
+        assert self._load({"DS_1": csv_path}, use_duckdb) == ['he"llo']
+
+    def test_csv_quoted_value(self, tmp_path: Path, use_duckdb):
+        """A quote delimiting a value is the file's dialect, and the reader takes it
+        off on its own: what is stored is the value, commas and all."""
+        csv_path = tmp_path / "DS_1.csv"
+        csv_path.write_text('Id_1,Me_1\n1,"a,b"\n')
+        assert self._load({"DS_1": csv_path}, use_duckdb) == ["a,b"]
+
+    def test_csv_escaped_quote(self, tmp_path: Path, use_duckdb):
+        """A quote written twice inside a quoted value is one quote in it."""
+        csv_path = tmp_path / "DS_1.csv"
+        csv_path.write_text('Id_1,Me_1\n1,"say ""hi"""\n')
+        assert self._load({"DS_1": csv_path}, use_duckdb) == ['say "hi"']


### PR DESCRIPTION
## Summary

The same String value loaded four ways gave three results and one different one: both CSV paths and the pandas DataFrame path deleted every `"` from it, while the DuckDb DataFrame path kept it, so `he"llo` compared equal or not depending on how it was handed to the engine.

There were two ways to make the four agree, and the choice was measured rather than guessed. Removing the stripping from every path and running the suites failed **one** test on the DuckDb engine and **none** on pandas — and that test is about a Boolean written as `"""TRUE"""`, not about a String. Nothing depended on taking quotes out of a String value, so the four paths agree by keeping the value instead of by spreading the loss to the fourth:

- The pandas loader stores a String value as it read it.
- The DuckDb CSV String branch stores it the same way; the Boolean branch keeps its own quote handling, which is what the `"""TRUE"""` case needs.
- The DuckDb DataFrame path is untouched — it was the one already storing the value whole.

A quote that delimits a value in a CSV is the file's dialect and both readers already take it off: `"a,b"` still loads as `a,b`.

> [!IMPORTANT]
> This also fixes a loss nobody had reported. A quote written twice inside a quoted value is one quote in that value, so a CSV holding `"say ""hi"""` means `say "hi"` — and it was loading as `say hi` on **both** engines. That case is one of the tests, and it fails on both when the source is reverted.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — 5666 passed on DuckDb, 5058 on pandas
- [ ] Documentation updated (if applicable)

## Impact / Risk

- **Behaviour change, and the point of the fix:** a String value holding a double quote now keeps it on the three paths that were deleting it. Anyone whose data contains quotes was silently losing them; results and CSV output change for exactly those values, and change to what the file said.
- Nothing is refused that was accepted before, and no error codes change.
- Boolean values written as `"""TRUE"""` load exactly as before.
- Data/SDMX compatibility: a value with no quote in it loads byte for byte as before.

Closes #1073

