### PR TITLE
Fix #1092: the required checks run inside the merge queue

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,6 +3,7 @@ name: Testing
 on:
   pull_request:
     branches: ["main", "1.6.X", "1.9.X"]
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ubuntu_test_24_04.yml
+++ b/.github/workflows/ubuntu_test_24_04.yml
@@ -3,6 +3,7 @@ name: Ubuntu 24.04 Tests
 on:
   pull_request:
     branches: ["main", "1.6.X", "1.9.X"]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, 1.6.X, 1.9.X ]
   pull_request:
     branches: [ main, 1.6.X, 1.9.X ]
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

A merge queue was enabled for `main` and `1.9.X` on 2026-08-27 (ruleset `main_dev_branches`), but the workflows behind the 17 required status checks only trigger on `pull_request`/`push`, which never fire on the queue's temporary `gh-readonly-queue/**` branches. Queued PRs therefore stall on "Expected" checks for 4 hours and are then removed from the queue. This adds a bare `merge_group:` trigger to the three workflows that produce required checks (`testing.yml`, `ubuntu_test_24_04.yml`, `version.yml`) so they also run for merge groups.

Fixes #1092

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [ ] Tests pass (`pytest`) — CI-only change; the full matrix runs on this PR
- [ ] Documentation updated (if applicable) — not applicable

## Impact / Risk

- CI-only; no API or behavior changes.
- Job names are unchanged, so the check contexts required by the ruleset (`testing (os, py)`, `test`, `check-versions`) keep matching under `merge_group`.
- The concurrency groups fall back to `github.ref` (the unique `gh-readonly-queue/...` ref) for `merge_group` events, so queue entries do not cancel each other.
- No bootstrap problem: a merge group is the PR merged onto its base, so this PR's own queue run already contains these triggers.

## Notes

- 1.9.X only; `main` needs the same change in a separate PR.
- `1.6.X` is not covered by the merge queue ruleset and is left untouched.
- Workflows validated with `actionlint` (clean) in addition to the standard quality gates.