### PR TITLE
Fix #894: a Date value keeps its time when a DataFrame carries it short or already parsed

### DIFF
--- a/src/vtlengine/DataTypes/_time_checking.py
+++ b/src/vtlengine/DataTypes/_time_checking.py
@@ -2,6 +2,7 @@ import calendar
 import re
 from datetime import date, datetime
 from functools import lru_cache
+from typing import Any
 
 from vtlengine.DataTypes.TimeHandling import TimePeriodHandler
 from vtlengine.Exceptions import InputValidationException
@@ -12,6 +13,21 @@ _DATE_PART_RE = re.compile(r"^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})")
 def _has_time_component(value: str) -> bool:
     """Check if a date string includes a time component (T or space separator at position 10)."""
     return len(value) > 10 and value[10] in ("T", " ")
+
+
+def _from_date_value(value: Any) -> str:
+    """The text of a value pandas has already parsed into a date or a datetime.
+
+    A datetime at midnight is written as the bare date it stands for, so a column of
+    dates reads as dates whether pandas parsed it or left it as text.
+    """
+    if isinstance(value, datetime):
+        if (value.hour, value.minute, value.second, value.microsecond) == (0, 0, 0, 0):
+            return value.strftime("%Y-%m-%d")
+        return value.isoformat(sep=" ")
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value)
 
 
 def _truncate_nanoseconds(value: str) -> str:
@@ -105,14 +121,19 @@ def _pad_date_parts(value: str) -> str:
     return f"{year}-{int(month):02d}-{int(day):02d}{rest}"
 
 
-def check_date(value: str) -> str:
+def check_date(value: Any) -> str:
     """Check a date is in the correct format.
 
     Accepts ``YYYY-MM-DD`` and ``YYYY-MM-DD[T| ]HH:MM:SS[.ffffff][+HH:MM|Z]`` (ISO 8601).
     A time component, when present, must be a COMPLETE ``HH:MM:SS``; partial times such
     as ``HH`` or ``HH:MM`` are rejected. Datetime output uses a single space separator;
     nanosecond input is truncated to microsecond precision.
+
+    A DataFrame may carry a column pandas has already parsed, so a date or a datetime
+    arrives as itself rather than as text. It used to reach here and raise a raw
+    AttributeError for the strip a string would have.
     """
+    value = _from_date_value(value)
     value = _pad_date_parts(value.strip())
     has_time = _has_time_component(value)
     try:

--- a/src/vtlengine/duckdb_transpiler/io/_io.py
+++ b/src/vtlengine/duckdb_transpiler/io/_io.py
@@ -6,6 +6,8 @@ This module contains the core load/save implementations to avoid circular import
 
 import csv
 import os
+import re
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple, Union
 
@@ -36,6 +38,10 @@ from vtlengine.files.sdmx_handler import (
 )
 from vtlengine.Model import Component, Dataset, Role, Scalar
 from vtlengine.Utils._number_config import format_scalar_value_for_csv
+
+# A Date value writes its time after the date, with the month and the day allowed to
+# be written short, as VALID_DATE_REGEX allows them.
+_DATE_WITH_TIME_RE = re.compile(r"^\d{4}-\d{1,2}-\d{1,2}[T ]")
 
 
 def _skip_load_validation() -> bool:
@@ -607,23 +613,35 @@ def extract_datapoint_paths(
     return path_dict if path_dict else None, df_dict
 
 
+def _carries_a_time(value: object) -> bool:
+    """Whether a Date input value writes a time beside the date.
+
+    A value is read the way the Date check reads it, rather than by looking for a
+    separator at a fixed place in text: a month or a day written short moved it
+    along, and a column pandas had already parsed carried no text to look at, so
+    either one was stored as a DATE and lost the time it held.
+    """
+    if isinstance(value, str):
+        return bool(_DATE_WITH_TIME_RE.match(value.strip()))
+    if isinstance(value, datetime):
+        return (value.hour, value.minute, value.second, value.microsecond) != (0, 0, 0, 0)
+    return False
+
+
 def _detect_date_type_overrides(
     df: pd.DataFrame, components: Dict[str, Component]
 ) -> Dict[str, str]:
     """Determine which Date columns need TIMESTAMP instead of DATE.
 
-    Inspects actual string values: if any value in a Date column has a time
-    component (length > 10 with 'T' or ' ' separator), the column is stored
-    as TIMESTAMP to preserve the time part. Otherwise DATE is used.
+    A Date column holding a value that writes a time is stored as TIMESTAMP to keep
+    that time; a column of bare dates is stored as DATE.
     """
     overrides: Dict[str, str] = {}
     for comp_name, comp in components.items():
         if comp.data_type != Date or comp_name not in df.columns:
             continue
-        for val in df[comp_name].dropna():
-            if isinstance(val, str) and len(val) > 10 and val[10] in ("T", " "):
-                overrides[comp_name] = "TIMESTAMP"
-                break
+        if any(_carries_a_time(val) for val in df[comp_name].dropna()):
+            overrides[comp_name] = "TIMESTAMP"
     return overrides
 
 

--- a/tests/DateTime/test_datetime.py
+++ b/tests/DateTime/test_datetime.py
@@ -157,6 +157,26 @@ dataload_params = [
         id="datetime_values",
     ),
     pytest.param(
+        ["2020-1-1T12:30:45", "2020-1-5 08:00:00"],
+        ["2020-01-01T12:30:45", "2020-01-05T08:00:00"],
+        id="month_and_day_written_short_with_time",
+    ),
+    pytest.param(
+        list(pd.to_datetime(["2020-01-01 12:30:45", "2020-06-15 23:59:59"])),
+        ["2020-01-01T12:30:45", "2020-06-15T23:59:59"],
+        id="already_parsed_datetime_with_time",
+    ),
+    pytest.param(
+        list(pd.to_datetime(["2020-01-01 12:30:45.123456"])),
+        ["2020-01-01T12:30:45.123456"],
+        id="already_parsed_datetime_with_microseconds",
+    ),
+    pytest.param(
+        list(pd.to_datetime(["2020-01-01", "2021-02-02"])),
+        ["2020-01-01", "2021-02-02"],
+        id="already_parsed_dates_stay_dates",
+    ),
+    pytest.param(
         ["2020-01-15T10:30:00", "2020-06-01T00:00:00"],
         ["2020-01-15T10:30:00", "2020-06-01T00:00:00"],
         id="t_separator_preserved",


### PR DESCRIPTION
## Summary

A Date value handed over in a DataFrame lost the time it carried, in two ways the CSV path handles correctly, and on `1.9.X` one of them does not truncate but crashes:

- **A month or a day written short.** `2020-1-1T12:30:45` moved the separator off position 10, which is where the override detection looked for it, so the column was created as `DATE` and the cast dropped the time. The same value in a CSV keeps it.
- **A column pandas had already parsed.** The detection read `isinstance(val, str)` only, so a `datetime64` column never triggered the override and came out as a bare date on the DuckDb engine. On the pandas engine it did not truncate: `check_date` assumed text and let a raw `AttributeError` escape — `'Timestamp' object has no attribute 'strip'` — for a column carrying a time **and** for one carrying only dates.

Both engines read such a value now:

- `check_date` takes what pandas hands it. A datetime becomes its ISO text; one sitting exactly at midnight becomes the bare date it stands for, so a parsed column of dates reads as dates rather than gaining a `T00:00:00`. A plain `date` object is read as well.
- `_detect_date_type_overrides` asks whether each value writes a time, rather than looking for a separator at a fixed place in text: a regex that allows a month or a day written short, as `VALID_DATE_REGEX` allows them, and a non-midnight check for a value already parsed.

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — 5718 passed on DuckDb, 5110 on pandas
- [ ] Documentation updated (if applicable)

## Impact / Risk

- A DataFrame column that lost its time now keeps it, on both engines. Results and CSV output change for exactly those values, and change to what the input said.
- A `datetime64` column no longer raises `AttributeError` on the pandas engine; it loads.
- Nothing that loaded correctly before changes: a column of bare dates, of date strings, or of strings carrying a time reads as it did.
- Data/SDMX compatibility: none.

## Notes

- Measured across eight input shapes, all agreeing on both engines: a month or day written short with a time, a parsed datetime with a time, with microseconds and date-only, Python `date` objects, plain date strings, strings carrying a time, and the same value through a CSV.
- The tests are new `dataload_params` entries in `tests/DateTime/test_datetime.py`, which is that file's DataFrame-load idiom and runs on whichever engine the suite is under. Reverting the source fails three of them on each engine, and not the same three: the DuckDb engine fails the short month and the parsed datetimes, while the pandas engine fails the three parsed cases, the date-only one among them, since that is the crash.

> [!NOTE]
> A Date column mixing values that carry a time with values that do not still renders every value with `T00:00:00` on the DuckDb engine. That is #1074, and it is not fixable where this fix lives: a TIMESTAMP sitting at midnight cannot say whether the input wrote a time, so the column-level decision has to guess. Closing it, and #895 with it, means having the DuckDb engine keep the form the value arrived in. `dataload_params[mixed_date_and_datetime]` still carries a per-engine expectation for that reason.

Closes #894
