### PR TITLE
Fix #1103: keep the caller's DataFrame untouched when the pandas engine loads it

### DIFF
--- a/src/vtlengine/files/parser/__init__.py
+++ b/src/vtlengine/files/parser/__init__.py
@@ -237,6 +237,12 @@ def _validate_pandas(
 ) -> pd.DataFrame:
     warnings.filterwarnings("ignore", category=FutureWarning)
 
+    # The DataFrame belongs to the caller: work on a shallow copy so the label
+    # normalization, the columns added for missing components and the value
+    # replacements below never reach it. No data is copied; every step that changes
+    # values assigns a new column.
+    data = data.copy(deep=False)
+
     # Strip UTF-8 BOM from column names (e.g. DataFrames read from BOM-encoded CSVs)
     bom_stripped = [str(col).removeprefix("\ufeff") for col in data.columns]
     data.columns = pd.Index(bom_stripped)

--- a/tests/DataLoad/test_dataload.py
+++ b/tests/DataLoad/test_dataload.py
@@ -1408,3 +1408,63 @@ class TestNullabilityFromDataFrame:
             pd.DataFrame({"Id_1": [1, 2], "Me_1": [1.0, None]}), use_duckdb, nullable=True
         )
         assert result["DS_r"].data["Me_1"].isnull().tolist() == [False, True]
+
+
+@pytest.mark.parametrize("use_duckdb", [False, True], ids=["pandas", "duckdb"])
+class TestInputDataFrameIsLeftUntouched:
+    """The DataFrame passed in ``datapoints`` belongs to the caller: loading it must not
+    add the components it does not carry, rename its labels or replace its values, on
+    either engine (issue #1103)."""
+
+    _structures = {
+        "datasets": [
+            {
+                "name": "DS_1",
+                "DataStructure": [
+                    {"name": "Id_1", "type": "Integer", "role": "Identifier", "nullable": False},
+                    {"name": "Me_1", "type": "Number", "role": "Measure", "nullable": True},
+                    {"name": "Me_2", "type": "String", "role": "Measure", "nullable": True},
+                ],
+            }
+        ]
+    }
+
+    def _run(self, data_df: pd.DataFrame, use_duckdb: bool) -> Any:
+        return run(
+            script="DS_r <- DS_1;",
+            data_structures=self._structures,
+            datapoints={"DS_1": data_df},
+            use_duckdb=use_duckdb,
+        )
+
+    def test_missing_nullable_measure(self, use_duckdb: bool) -> None:
+        """Me_2 is not provided: the result carries it as null, the caller's DataFrame
+        does not get it."""
+        data_df = pd.DataFrame({"Id_1": [1, 2, 3], "Me_1": [10.0, 20.0, 30.0]})
+        snapshot = data_df.copy()
+
+        result = self._run(data_df, use_duckdb)
+
+        assert result["DS_r"].data["Me_2"].isnull().all()
+        assert list(data_df.columns) == list(snapshot.columns)
+        pd.testing.assert_frame_equal(data_df, snapshot)
+
+    def test_labels_and_empty_strings(self, use_duckdb: bool) -> None:
+        """A BOM-prefixed label and an empty string in a Number column are normalized
+        for the engine, not on the caller's DataFrame."""
+        if use_duckdb:
+            pytest.skip(
+                "the DuckDB engine does not take these inputs on this branch: the BOM label "
+                "is rejected as an undefined column until PR #1100 and an empty string in a "
+                "Number column fails to convert"
+            )
+        data_df = pd.DataFrame(
+            {"\ufeffId_1": [1, 2, 3], "Me_1": [10.0, "", 30.0], "Me_2": ["a", "b", "c"]}
+        )
+        snapshot = data_df.copy()
+
+        result = self._run(data_df, use_duckdb)
+
+        assert result["DS_r"].data["Me_1"].isnull().tolist() == [False, True, False]
+        assert list(data_df.columns) == list(snapshot.columns)
+        pd.testing.assert_frame_equal(data_df, snapshot)


### PR DESCRIPTION
## Summary

With the pandas engine (the default), `run()` modified the DataFrame the caller passed in `datapoints`: `_validate_pandas` rewrote its labels (BOM strip, `str` coercion), added a column for every nullable component the frame did not carry and replaced empty strings in non-String columns with `NA`, all on the caller's object, before `fillna` produced a new frame. It now works on a shallow copy of the DataFrame, which isolates the labels and the column set without copying any data; every later value change already assigns a new column. The DuckDB engine never touched the frame, so the two engines now behave the same.

`TestInputDataFrameIsLeftUntouched` in `tests/DataLoad` pins it on both engines (missing nullable measure) and on pandas (BOM label and empty string); both pandas cases failed before the change.

Fixes #1103

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — full suite on both engines: DuckDB 5788 passed / 28 skipped, pandas 5175 passed / 641 skipped
- [ ] Documentation updated (if applicable) — not applicable

## Impact / Risk

- Behaviour change: the DataFrame a caller passes as `datapoints` is no longer modified in place by the pandas engine. Code that relied on the side effect (reading the normalized labels or the added columns from its own frame after `run()`) would notice; the returned datasets are unchanged.
- No memory cost: the copy is shallow and the data blocks stay shared until a column is replaced.
- No SDMX compatibility concerns.

## Notes

- The labels/empty-string case is skipped on the DuckDB engine on this branch: the BOM label is rejected as an undefined column until PR #1100 lands, and an empty string in a Number column fails DuckDB's `CAST` (`Could not convert string '' to DOUBLE`) while the pandas engine reads it as null. That second divergence is fixed on the DuckDB side in PR #1100 as well (string-like source columns are read through `NULLIF(..., '')` for the non-String types), so once #1100 lands on 1.9.X both reasons for the skip are gone and the case can run on both engines.

