### PR TITLE
Fix #1106: time_agg binds its operand once instead of nesting the time macros

### DIFF
--- a/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
+++ b/src/vtlengine/duckdb_transpiler/Transpiler/__init__.py
@@ -270,6 +270,10 @@ class SQLTranspiler(StructureVisitor, ASTTemplate):
     # Hierarchical rulesets
     _hrs: Dict[str, Dict[str, Any]] = field(default_factory=dict, init=False)
 
+    # Sub-expressions to precompute in the source subquery, innermost scope last
+    _hoisted: List[List[str]] = field(default_factory=list, init=False)
+    _hoist_count: int = field(default=0, init=False)
+
     def __post_init__(self) -> None:
         """Initialize available tables."""
         self.datasets = {**self.input_datasets, **self.output_datasets}
@@ -295,6 +299,37 @@ class SQLTranspiler(StructureVisitor, ASTTemplate):
             self._in_clause = old_in_clause
             self._current_dataset = old_current_ds
             self._column_prefix = old_prefix
+
+    @contextmanager
+    def _hoist_scope(self) -> Generator[List[str], None, None]:
+        """Collect the sub-expressions hoisted while building one statement."""
+        self._hoisted.append([])
+        try:
+            yield self._hoisted[-1]
+        finally:
+            self._hoisted.pop()
+
+    def _hoist(self, expr_sql: str) -> str:
+        """Precompute *expr_sql* in the source subquery and return its column name.
+
+        DuckDB expands a scalar macro by substituting the argument at every place
+        the parameter is used, so a nested chain of macros multiplies copies of the
+        inner expressions and the binder pays for each one. Reading the expression
+        from a column instead binds it once (issue #1106). Returns the expression
+        unchanged when no enclosing statement can hold the extra column.
+        """
+        if not self._hoisted:
+            return expr_sql
+        alias = quote_name(f"_vtl_h{self._hoist_count}")
+        self._hoist_count += 1
+        self._hoisted[-1].append(f"{expr_sql} AS {alias}")
+        return alias
+
+    def _hoisted_source(self, src: str, hoisted: List[str]) -> str:
+        """Add the hoisted columns to *src*, leaving it alone when there are none."""
+        if not hoisted:
+            return src
+        return f"(SELECT *, {', '.join(hoisted)} FROM {self._as_subquery(src)} AS _vtl_h)"
 
     @contextmanager
     def _stash_assignment(self) -> Generator[None, None, None]:
@@ -372,9 +407,12 @@ class SQLTranspiler(StructureVisitor, ASTTemplate):
 
                 is_persistent = isinstance(child, AST.PersistentAssignment)
                 if name in self.output_scalars:
-                    value_sql = self.visit(child)
-                    if not value_sql.strip().upper().startswith("SELECT"):
-                        value_sql = f"SELECT {value_sql} AS value"
+                    with self._hoist_scope() as hoisted:
+                        value_sql = self.visit(child)
+                        if not value_sql.strip().upper().startswith("SELECT"):
+                            value_sql = f"SELECT {value_sql} AS value"
+                            if hoisted:
+                                value_sql += f" FROM (SELECT {', '.join(hoisted)}) AS _vtl_h"
                     queries.append((name, value_sql, is_persistent))
                 else:
                     query = self.visit(child)
@@ -1689,7 +1727,7 @@ FROM (
         ds, table_src = resolved
 
         calc_exprs: Dict[str, str] = {}
-        with self._clause_scope(ds):
+        with self._hoist_scope() as hoisted, self._clause_scope(ds):
             for child in node.children:
                 assignment = self._unwrap_assignment(child)
                 if isinstance(assignment, AST.Assignment):
@@ -1716,7 +1754,7 @@ FROM (
             if col_name not in ds.components:
                 select_cols.append(f"{expr_sql} AS {quote_name(col_name)}")
 
-        inner_src = self._as_subquery(table_src)
+        inner_src = self._as_subquery(self._hoisted_source(table_src, hoisted))
 
         return SQLBuilder().select(*select_cols).from_table(inner_src, "t").build()
 
@@ -1851,27 +1889,29 @@ FROM (
         grouping_names: List[str] = []
         time_agg_expr: Optional[str] = None
         time_agg_id: Optional[str] = None
-        for child in node.children:
-            assignment = self._unwrap_assignment(child)
-            if isinstance(assignment, AST.Assignment):
-                agg_node = assignment.right
-                if isinstance(agg_node, AST.Aggregation) and agg_node.grouping:
-                    grouping_op = agg_node.grouping_op or ""
-                    for g in agg_node.grouping:
-                        if isinstance(g, (AST.VarID, AST.Identifier)):
-                            resolved = self._resolve_udo_name(g.value)
-                            if resolved not in grouping_names:
-                                grouping_names.append(resolved)
-                        elif isinstance(g, AST.TimeAggregation) and time_agg_expr is None:
-                            with self._clause_scope(ds):
-                                time_agg_expr = self.visit_TimeAggregation(g)
-                            for comp in ds.components.values():
-                                if (
-                                    comp.data_type in (TimePeriod, Date)
-                                    and comp.role == Role.IDENTIFIER
-                                ):
-                                    time_agg_id = comp.name
-                                    break
+        with self._hoist_scope() as hoisted:
+            for child in node.children:
+                assignment = self._unwrap_assignment(child)
+                if isinstance(assignment, AST.Assignment):
+                    agg_node = assignment.right
+                    if isinstance(agg_node, AST.Aggregation) and agg_node.grouping:
+                        grouping_op = agg_node.grouping_op or ""
+                        for g in agg_node.grouping:
+                            if isinstance(g, (AST.VarID, AST.Identifier)):
+                                resolved = self._resolve_udo_name(g.value)
+                                if resolved not in grouping_names:
+                                    grouping_names.append(resolved)
+                            elif isinstance(g, AST.TimeAggregation) and time_agg_expr is None:
+                                with self._clause_scope(ds):
+                                    time_agg_expr = self.visit_TimeAggregation(g)
+                                for comp in ds.components.values():
+                                    if (
+                                        comp.data_type in (TimePeriod, Date)
+                                        and comp.role == Role.IDENTIFIER
+                                    ):
+                                        time_agg_id = comp.name
+                                        break
+            group_src = self._hoisted_source(table_src, hoisted)
 
         all_input_ids = list(ds.get_identifiers_names())
         if grouping_op == "group by":
@@ -1911,7 +1951,7 @@ FROM (
             else:
                 cols.append(f"{vp_group_sql(v_rule, v_qn)} AS {v_qn}")
 
-        builder = SQLBuilder().select(*cols).from_table(table_src)
+        builder = SQLBuilder().select(*cols).from_table(group_src)
         if group_ids:
             builder.group_by(*[_id_group_sql(id_) for id_ in group_ids])
 
@@ -2100,7 +2140,9 @@ FROM (
         # Resolve group columns from input identifiers.
         all_ids = ds.get_identifiers_names()
         group_cols = self._resolve_group_cols(node, all_ids)
-        cols, group_by_cols = self._build_agg_group_cols(node, ds, group_cols)
+        with self._hoist_scope() as hoisted:
+            cols, group_by_cols = self._build_agg_group_cols(node, ds, group_cols)
+            group_src = self._hoisted_source(table_src, hoisted)
         ds_tp_minmax_cols: List[tuple[str, str]] = []
 
         # count() produces a single int_var measure.
@@ -2140,7 +2182,7 @@ FROM (
             else:
                 cols.append(f"{vp_group_sql(v_rule, v_qn)} AS {v_qn}")
 
-        builder = SQLBuilder().select(*cols).from_table(table_src)
+        builder = SQLBuilder().select(*cols).from_table(group_src)
 
         if group_cols:
             builder.group_by(*group_by_cols)
@@ -3844,7 +3886,8 @@ FROM (
 
             operand_sql = self.visit(node.operand)
             if self._is_operand_type(node.operand, TimePeriod):
-                return f"vtl_time_agg_tp(vtl_period_parse({operand_sql}), '{target}')"
+                parsed = self._hoist(f"vtl_period_parse({operand_sql})")
+                return f"vtl_time_agg_tp({parsed}, '{target}')"
             else:
                 agg_expr = f"vtl_time_agg_date({operand_sql}, '{target}')"
                 return self._apply_time_agg_conf(agg_expr, conf)
@@ -3854,7 +3897,8 @@ FROM (
                 for comp in self._current_dataset.components.values():
                     if comp.data_type == TimePeriod and comp.role == Role.IDENTIFIER:
                         col = quote_name(comp.name)
-                        return f"vtl_time_agg_tp(vtl_period_parse({col}), '{target}')"
+                        parsed = self._hoist(f"vtl_period_parse({col})")
+                        return f"vtl_time_agg_tp({parsed}, '{target}')"
                 for comp in self._current_dataset.components.values():
                     if comp.data_type == Date and comp.role == Role.IDENTIFIER:
                         col = quote_name(comp.name)
@@ -3862,13 +3906,12 @@ FROM (
                         return self._apply_time_agg_conf(agg, conf)
             return f"vtl_time_agg_date(CURRENT_DATE, '{target}')"
 
-    @staticmethod
-    def _apply_time_agg_conf(expr: str, conf: Optional[str]) -> str:
+    def _apply_time_agg_conf(self, expr: str, conf: Optional[str]) -> str:
         """Apply time_agg conf (first/last) modifier to a Date aggregation expression."""
-        if conf == "first":
-            return f"vtl_tp_start_date(vtl_period_parse({expr}))"
-        if conf == "last":
-            return f"vtl_tp_end_date(vtl_period_parse({expr}))"
+        if conf in ("first", "last"):
+            parsed = self._hoist(f"vtl_period_parse({expr})")
+            edge = "start" if conf == "first" else "end"
+            return f"vtl_tp_{edge}_date({parsed})"
         return expr
 
     def _resolve_period_to_ref(self, ref: AST.AST) -> str:
@@ -3891,17 +3934,20 @@ FROM (
 
         # Find time measures to transform
         cols = []
-        for comp in ds.components.values():
-            col = quote_name(comp.name)
-            if comp.role == Role.IDENTIFIER:
-                cols.append(col)
-            elif comp.data_type == TimePeriod:
-                cols.append(f"vtl_time_agg_tp(vtl_period_parse({col}), '{target}') AS {col}")
-            elif comp.data_type == Date:
-                expr = self._apply_time_agg_conf(f"vtl_time_agg_date({col}, '{target}')", conf)
-                cols.append(f"{expr} AS {col}")
-            else:
-                cols.append(col)
+        with self._hoist_scope() as hoisted:
+            for comp in ds.components.values():
+                col = quote_name(comp.name)
+                if comp.role == Role.IDENTIFIER:
+                    cols.append(col)
+                elif comp.data_type == TimePeriod:
+                    parsed = self._hoist(f"vtl_period_parse({col})")
+                    cols.append(f"vtl_time_agg_tp({parsed}, '{target}') AS {col}")
+                elif comp.data_type == Date:
+                    expr = self._apply_time_agg_conf(f"vtl_time_agg_date({col}, '{target}')", conf)
+                    cols.append(f"{expr} AS {col}")
+                else:
+                    cols.append(col)
+            src = self._hoisted_source(src, hoisted)
 
         return SQLBuilder().select(*cols).from_table(src).build()
 

--- a/tests/duckdb_transpiler/test_time_transpiler.py
+++ b/tests/duckdb_transpiler/test_time_transpiler.py
@@ -16,6 +16,7 @@ from vtlengine.AST import (
     VarID,
 )
 from vtlengine.DataTypes import Number, TimeInterval, TimePeriod
+from vtlengine.duckdb_transpiler import transpile
 from vtlengine.duckdb_transpiler.sql import initialize_time_types
 from vtlengine.duckdb_transpiler.Transpiler import SQLTranspiler
 from vtlengine.Model import Component, Dataset, Role
@@ -260,5 +261,86 @@ class TestSQLInitialization:
                 conn.execute(sql).fetchone()
             except Exception as e:
                 pytest.fail(f"Function test failed: {sql}\nError: {e}")
+
+        conn.close()
+
+
+# =============================================================================
+# Tests: time_agg operand binding (#1106)
+# =============================================================================
+
+
+TIME_AGG_STRUCTURE = {
+    "datasets": [
+        {
+            "name": "DS_1",
+            "DataStructure": [
+                {"name": "Id_1", "type": "String", "role": "Identifier", "nullable": False},
+                {"name": "Id_2", "type": "Date", "role": "Identifier", "nullable": False},
+                {"name": "Me_1", "type": "Integer", "role": "Measure", "nullable": True},
+            ],
+        },
+        {
+            "name": "DS_2",
+            "DataStructure": [
+                {"name": "Id_1", "type": "String", "role": "Identifier", "nullable": False},
+                {"name": "Id_2", "type": "Time_Period", "role": "Identifier", "nullable": False},
+                {"name": "Me_1", "type": "Integer", "role": "Measure", "nullable": True},
+            ],
+        },
+    ]
+}
+
+
+class TestTimeAggOperandBoundOnce:
+    """time_agg reads its operand from a column instead of nesting the macros.
+
+    DuckDB substitutes a macro argument at every place the parameter is used, so a
+    nested chain of time macros multiplies copies of the inner expressions and the
+    binder pays seconds for each statement (#1106).
+    """
+
+    @pytest.mark.parametrize(
+        "script,outer",
+        [
+            (
+                "DS_r <- DS_1[calc identifier Id_3 := "
+                'time_agg("M", "D", cast(Id_2, time_period))];',
+                "vtl_time_agg_tp",
+            ),
+            ('DS_r <- DS_2[calc Me_2 := time_agg("A", Id_2)];', "vtl_time_agg_tp"),
+            (
+                'DS_r <- DS_2[aggr Me_2 := sum(Me_1) group all time_agg("A")];',
+                "vtl_time_agg_tp",
+            ),
+            ('DS_r <- sum(DS_2 group all time_agg("A"));', "vtl_time_agg_tp"),
+            ('DS_r <- sum(DS_1 group all time_agg("A", last));', "vtl_tp_end_date"),
+            ('sc <- time_agg("A", cast("2020-05-05", date), first);', "vtl_tp_start_date"),
+        ],
+    )
+    def test_operand_read_from_a_column(self, script, outer):
+        """The operand is computed once as a column and the macro reads that column."""
+        sql = normalize_sql(transpile(script, TIME_AGG_STRUCTURE)[0][1])
+
+        assert f'{outer}("_vtl_h0"' in sql, sql
+        assert 'AS "_vtl_h0"' in sql, sql
+        assert f"{outer}(vtl_period_parse" not in sql, sql
+
+    def test_hoisted_sql_executes(self):
+        """The precomputed column is in scope: the generated SQL runs and aggregates."""
+        conn = duckdb.connect(":memory:")
+        initialize_time_types(conn)
+        conn.execute(
+            'CREATE TABLE "DS_1" AS SELECT * FROM (VALUES'
+            " ('A', '2024-02-29', 1), ('A', '2024-03-01', 2)) v(\"Id_1\", \"Id_2\", \"Me_1\")"
+        )
+
+        script = (
+            'DS_r <- DS_1[calc identifier Id_3 := time_agg("M", "D", cast(Id_2, time_period))];'
+        )
+        _, sql, _ = transpile(script, TIME_AGG_STRUCTURE)[0]
+        rows = conn.execute(f'SELECT "Id_3" FROM ({sql}) ORDER BY 1').fetchall()
+
+        assert rows == [("2024-M02",), ("2024-M03",)]
 
         conn.close()


### PR DESCRIPTION
## Summary

On DuckDB, `time_agg("M", "D", cast(Id_2, time_period))` spent about 3 s per statement inside
the binder and optimizer, independent of the row count. DuckDB expands a scalar macro by
substituting the argument at every place the parameter is used, so
`vtl_time_agg_tp(vtl_period_parse(vtl_date_to_period(col)), 'M')` multiplied copies of the
inner expressions at each level, and the binder processed all of them.

The transpiler now precomputes such an operand as a column of the statement's source
subquery and applies the outer macro to that column, so the expression is bound once:

```sql
SELECT "Id_1", "Id_2", "Me_1", vtl_time_agg_tp("_vtl_h0", 'M') AS "Id_3"
FROM (SELECT *, vtl_period_parse(vtl_date_to_period("Id_2")) AS "_vtl_h0" FROM ...) AS t
```

`_hoist_scope()` / `_hoist()` / `_hoisted_source()` are general: a visitor asks for a
sub-expression to be precomputed and gets back the column name, and the statement builder
adds those columns to its source. It is wired into `time_agg` at component, clause,
aggregation, dataset and scalar level. Where no enclosing statement can hold the extra
column, the expression is emitted unchanged.

Measured on this branch:

| | before | after |
| --- | --- | --- |
| The issue's script (2 rows) | 3.13 s | 0.06 s |
| The same shape, 500 000 rows | 6.53 s | 1.60 s |
| `tests/Aggregate` `test_GL_466_1` | 3.52 s | 0.13 s |
| Whole suite | 160.6 s | 154.7 s |

## Checklist

- [x] Code quality checks pass (`ruff format`, `ruff check`, `mypy`)
- [x] Tests pass (`pytest`) — 5060 passed, 11 skipped
- [ ] Documentation updated (if applicable)

## Impact / Risk

- No behaviour change: the same values come back on every `time_agg` shape, error paths
  included. Only the shape of the generated SQL changes.
- No API or SDMX compatibility concerns.
- Release note: `time_agg` statements no longer cost seconds of planning each.

## Notes

- Binding the argument inside the SQL macros instead (`list_transform([p], q -> ...)[1]`)
  removes the same planning cost but makes per-row evaluation 5.4× slower (0.115 s → 0.622 s
  on 2 M rows), so it was discarded in favour of the subquery column.
- The `2-1-1-16` calc-identifier null guard named in the issue does not exist on `main`, so
  only items 1 and 3 of the issue applied here.
- The defect also reproduces on `1.9.X` (6.60 s, doubled there by that null guard). If a
  `1.9.X` fix is wanted, it needs its own branch.
- Reverting the transpiler change fails 6 of the 7 new parametrized cases in
  `tests/duckdb_transpiler/test_time_transpiler.py`; the seventh executes the generated SQL
  and guards against an out-of-scope precomputed column.

Closes #1106

